### PR TITLE
Add text columns to heatmap

### DIFF
--- a/src/SDK/D3Heatmap.js
+++ b/src/SDK/D3Heatmap.js
@@ -93,18 +93,40 @@ export function drawHeatmap(d3, selector, summary) {
     };
 
     function addColumns(gElement, summaryEntry=null) {
-        var colWidth = 45;
-        var columns = ["score", "pctid", "aln", "glb", "cvgpct"];
-        if (summaryEntry) {
-            columns = columns.map((col) => summaryEntry[col]);
+        var colHeight = sectionHeight;
+        var columnNameMap = {
+            "score": "Score",
+            "pctid": "Identity%",
+            "cvgpct": "Coverage%",
+            "aln": "Reads"
         }
+        var columnSizeMap = {
+            "score": 50,
+            "pctid": 80,
+            "cvgpct": 88,
+            "aln": 70
+        }
+        var columns = ["score", "pctid", "aln", "cvgpct"];
         var textG = gElement.append("g")
             .attr("transform",
                   `translate(${sectionMargin.left + barWidth + 10}, 15)`);
-        columns.forEach((column, i) => {
+        var prevWidth = 0;
+        columns.forEach((column) => {
+            var colWidth = columnSizeMap[column];
+            var colText = summaryEntry ? summaryEntry[column] : columnNameMap[column];
+            textG.append("rect")
+                .attr("fill", "none")
+                .style("stroke", "black")
+                .style("stroke-width", 1)
+                .attr("width", colWidth)
+                .attr("height", colHeight)
+                .attr("x", prevWidth)
+                .attr("y", -15);
             textG.append("text")
-                .text(column)
-                .attr("x", colWidth * i);
+                .text(colText)
+                .style("text-anchor", "middle")
+                .attr("x", prevWidth + (colWidth / 2));
+            prevWidth += colWidth;
         });
     }
 

--- a/src/SDK/D3Heatmap.js
+++ b/src/SDK/D3Heatmap.js
@@ -122,7 +122,7 @@ export function drawHeatmap(d3, selector, summary) {
         else {
             link = `https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?name=${family.family}`;
             linkText = "NCBI Taxonomy Browser";
-            linkWidth = 170;
+            linkWidth = 175;
         }
         var linkHeight = 20;
         var linkSvg = textGroup.append("svg")
@@ -379,8 +379,7 @@ export function drawHeatmap(d3, selector, summary) {
 
     var chartSvg = d3.select(selector)
         .append("svg")
-        .attr("width", 750)
-        .attr("height", 660);
+        .attr("viewBox", `0 0 750 660`);
     var familiesSvg = chartSvg.append("svg")
         .attr("y", 20);
 

--- a/src/SDK/D3Heatmap.js
+++ b/src/SDK/D3Heatmap.js
@@ -364,7 +364,7 @@ export function drawHeatmap(d3, selector, summary) {
     }
 
     var sectionMargin = {top: 2, right: 300, bottom: 2, left: 200};
-    var sectionWidth = 800;
+    var sectionWidth = 750;
     var sectionHeight = 20;
     var barWidth = sectionWidth - sectionMargin.left - sectionMargin.right;
     var barHeight = sectionHeight - sectionMargin.top - sectionMargin.bottom;
@@ -379,7 +379,7 @@ export function drawHeatmap(d3, selector, summary) {
 
     var chartSvg = d3.select(selector)
         .append("svg")
-        .attr("width", 800)
+        .attr("width", 750)
         .attr("height", 660);
     var familiesSvg = chartSvg.append("svg")
         .attr("y", 20);

--- a/src/SDK/D3Heatmap.js
+++ b/src/SDK/D3Heatmap.js
@@ -161,31 +161,29 @@ export function drawHeatmap(d3, selector, summary) {
                         .attr("y", -yShift);
                 }
             }
-            else {
-                var tooltipFontSize = 10;
-                var tooltipX = sectionMargin.left + barWidth + prevWidth + (colWidth / 2);
-                var tooltipY = 15;
-                var hoverForColumnText = textG.append("rect")
-                    .attr("width", colWidth)
-                    .attr("height", colHeight)
-                    .attr("x", prevWidth)
-                    .attr("y", -yShift)
-                    .style("opacity", 0)
-                    .on("mouseover", () => {
-                        d3.selectAll(`[column="${column}"]`).style("opacity", 1);
-                        d3.select("#tooltip")
-                            .text(colAttrs["desc"])
-                            .attr("font-size", tooltipFontSize)
-                            .attr("x", tooltipX)
-                            .attr("y", tooltipY)
-                            .style("text-anchor", "middle")
-                            .style("opacity", 1);
-                    })
-                    .on("mouseout", () => {
-                        d3.selectAll(`[column="${column}"]`).style("opacity", 0);
-                        d3.select("#tooltip").style("opacity", 0);
-                    });
-            }
+            var tooltipFontSize = 10;
+            var tooltipX = sectionMargin.left + barWidth + prevWidth + (colWidth / 2);
+            var tooltipY = 15;
+            var hoverForColumnText = textG.append("rect")
+                .attr("width", colWidth)
+                .attr("height", colHeight)
+                .attr("x", prevWidth)
+                .attr("y", -yShift)
+                .style("opacity", 0)
+                .on("mouseover", () => {
+                    d3.selectAll(`[column="${column}"]`).style("opacity", 1);
+                    d3.select("#tooltip")
+                        .text(colAttrs["desc"])
+                        .attr("font-size", tooltipFontSize)
+                        .attr("x", tooltipX)
+                        .attr("y", tooltipY)
+                        .style("text-anchor", "middle")
+                        .style("opacity", 1);
+                })
+                .on("mouseout", () => {
+                    d3.selectAll(`[column="${column}"]`).style("opacity", 0);
+                    d3.select("#tooltip").style("opacity", 0);
+                });
 
             prevWidth += colWidth;
         });

--- a/src/SDK/D3Heatmap.js
+++ b/src/SDK/D3Heatmap.js
@@ -92,6 +92,22 @@ export function drawHeatmap(d3, selector, summary) {
             .call(d3.axisRight(legendScale));
     };
 
+    function addColumns(gElement, summaryEntry=null) {
+        var colWidth = 45;
+        var columns = ["score", "pctid", "aln", "glb", "cvgpct"];
+        if (summaryEntry) {
+            columns = columns.map((col) => summaryEntry[col]);
+        }
+        var textG = gElement.append("g")
+            .attr("transform",
+                  `translate(${sectionMargin.left + barWidth + 10}, 15)`);
+        columns.forEach((column, i) => {
+            textG.append("text")
+                .text(column)
+                .attr("x", colWidth * i);
+        });
+    }
+
     function addFamilyText(gElement, family) {
         var textGroup = gElement.append("g")
             .attr("transform",
@@ -249,16 +265,10 @@ export function drawHeatmap(d3, selector, summary) {
         var shiftY = subSectionVisible ? -subsectionHeight : subsectionHeight;
         toggleIRow(allRows, currentRow, subsectionHeight);
         shiftLowerFamilies(familyName, shiftY);
-
     }
 
     function drawExpandableRow(gElement, name, dataBin, heatSquareData, rowIndex) {
         var rowType = dataBin;
-        var sectionWidth = 600;
-        var sectionHeight = 20;
-        var barWidth = sectionWidth - sectionMargin.left - sectionMargin.right;
-        var barHeight = sectionHeight - sectionMargin.top - sectionMargin.bottom;
-        var barBorder = {size: 1, color: '#999'};
 
         y = rowIndex * sectionHeight;
         var entrySvg = gElement.append("svg")
@@ -285,7 +295,9 @@ export function drawHeatmap(d3, selector, summary) {
             .call(d3.axisLeft(y));
         yAxis.select("path").remove();
         yAxis.select("line").remove();
-        yAxis.selectAll("text").attr("x", -25);
+        yAxis.selectAll("text")
+            .attr("x", -25)
+            .style("font-size", 12);
         
         var caret = yAxis.append("g")
             .attr("transform", `translate(-12, 9)`)
@@ -351,7 +363,12 @@ export function drawHeatmap(d3, selector, summary) {
         return subsection
     }
 
-    var sectionMargin = {top: 2, right: 100, bottom: 2, left: 150};
+    var sectionMargin = {top: 2, right: 300, bottom: 2, left: 200};
+    var sectionWidth = 800;
+    var sectionHeight = 20;
+    var barWidth = sectionWidth - sectionMargin.left - sectionMargin.right;
+    var barHeight = sectionHeight - sectionMargin.top - sectionMargin.bottom;
+    var barBorder = {size: 1, color: '#999'};
 
     var colorMap = d3.scaleSequential(d3.interpolateYlOrRd)
         .domain([0, 1]);
@@ -362,12 +379,13 @@ export function drawHeatmap(d3, selector, summary) {
 
     var chartSvg = d3.select(selector)
         .append("svg")
-        .attr("width", 600)
-        .attr("height", 1000);
+        .attr("width", 800)
+        .attr("height", 660);
     var familiesSvg = chartSvg.append("svg")
         .attr("y", 20);
 
     drawLegend();
+    addColumns(chartSvg);
 
     var familyTextHeight = 50;
 
@@ -385,6 +403,7 @@ export function drawHeatmap(d3, selector, summary) {
             .attr("class", "family")
             .attr("rowid", `${family.family}`);
         var familySubGroup = drawExpandableRow(familyG, family.family, "family", familyCoverageData, i);
+        addColumns(familyG.select("svg"), family);
         addFamilyText(familySubGroup, family);
 
         var familyAccessionsG = familySubGroup.append("g")
@@ -405,6 +424,7 @@ export function drawHeatmap(d3, selector, summary) {
             var accessionSubGroup = drawExpandableRow(
                 accessionG, accession.acc, "accession",
                 accessionCoverageData, i);
+            addColumns(accessionG.select("svg"), accession);
             addAccessionText(accessionSubGroup, family, accession);
         });
     });

--- a/src/pages/Data.js
+++ b/src/pages/Data.js
@@ -115,26 +115,9 @@ const Data = (props) => {
                             {entrezStudyName ? <div className="text-xl italic">Study: {entrezStudyName}</div> : <div></div>}
                         </div>
                     </div>
-                <div className="flex h-64 flex-col justify-end items-center w-5/6 bg-gray-400 border rounded-lg border-gray-600 shadow-xl m-1">
-                    <div class="w-600 h-64 overflow-y-auto">
-                        {sraAccession ? <Heatmap accession={sraAccession}></Heatmap> : <div></div>}
-                    </div>
-                </div>
-                <div className="flex flex-col h-64 w-5/6 bg-gray-400 border rounded-lg border-gray-600 shadow-xl overflow-y-auto m-1">
-                    <div className="text-center text-xl border-gray-800 border-1 p-1 italic">Families:</div>
-                        <div className="overflow-y-auto">
-                            <div className="h-full ">
-                                {summaryJson.families ?
-                                    summaryJson.families.map(family => (
-                                    <div key={family.family} className="flex flex-row justify-between border rounded-md bg-gray-300 border-gray-700 p-2 italic m-1 cursor-pointer">
-                                            <div>{family.family} </div>
-                                            <div> Cvg: {family.cvg} </div>
-                                            <div> Score: {family.score} </div>
-                                            <div> PctId: {family.pctid} </div>
-                                    </div>
-                                    )) : <div>{sraAccession ? "Loading..." : ""}</div>
-                                }
-                            </div>
+                    <div className="flex flex-col justify-end items-center w-5/6 bg-gray-400 border rounded-lg border-gray-600 shadow-xl m-1">
+                        <div class="w-auto h-auto overflow-y-auto">
+                            {sraAccession ? <Heatmap accession={sraAccession}></Heatmap> : <div></div>}
                         </div>
                     </div>
                 </div>

--- a/src/pages/Data.js
+++ b/src/pages/Data.js
@@ -116,7 +116,7 @@ const Data = (props) => {
                         </div>
                     </div>
                     <div className="flex flex-col justify-end items-center w-5/6 bg-gray-400 border rounded-lg border-gray-600 shadow-xl m-1">
-                        <div class="w-auto h-auto overflow-y-auto">
+                        <div class="w-5/6 h-auto overflow-y-auto">
                             {sraAccession ? <Heatmap accession={sraAccession}></Heatmap> : <div></div>}
                         </div>
                     </div>


### PR DESCRIPTION
Live preview: https://dev-text-columns.serratus.io/data?accession=ERR2756788

- add side table with columns: `Score`, `Identity%`, `Reads`, `Coverage%`
- increase font size of family/accession labels
- increase overall width, make SVG responsive (`viewBox`)
- remove families text section