### PR TITLE
Fix report page search loading issue

### DIFF
--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -32,7 +32,6 @@ const Report = (props) => {
     }
 
     function loadAccessionPage(accession) {
-        setAccession(accession);
         let newUrl = accession ? `${pathName}?accession=${accession}` : pathName;
         window.location.href = newUrl;
     }


### PR DESCRIPTION
Issue: search invocation fails to reload to desired report page. Observed on Firefox, Chrome browsers.

Cause: premature setting of `sraAccession` caused this condition to be true in the wrong scenario:

```js
// clicked "Report" on navigation bar
if (sraAccession && !currentAccession) {
    loadAccessionPage(currentAccession);
}
```