### PR TITLE
Fix bottomless report page display

### DIFF
--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -78,7 +78,7 @@ const Report = (props) => {
             <div className="flex flex-col justify-center items-center w-full z-10 rounded-lg p-1
                 sm:shadow-2xl
                 lg:w-3/4 lg:mt-6 lg:bg-blue-400 lg:bg-opacity-25 lg:border lg:border-gray-600">
-                <div className="w-full lg:w-5/6 bg-gray-400 border rounded-lg border-gray-600 sm:shadow-xl p-1 z-20 m-1">
+                <div className="w-full lg:w-5/6 bg-gray-400 border rounded-lg border-gray-600 sm:shadow-xl p-2 z-20 m-1">
                     {searchBox}
                     {sraAccession ? pageLinks : <div></div>}
                     <div className="w-full text-center text-xl">

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -86,7 +86,7 @@ const Report = (props) => {
                     </div>
                 </div>
                 <div className="w-full lg:w-5/6 flex flex-col flex-1 justify-center items-center bg-gray-400 border rounded-lg border-gray-600 shadow-xl m-1 sm:px-12">
-                    <div className="w-full flex flex-col overflow-y-auto" style={{ height: 600 }} id="style-2">
+                    <div className="w-full flex flex-col overflow-y-auto pl-12" style={{ height: 600 }} id="style-2">
                         {sraAccession ?
                             <ReportChart accession={sraAccession}></ReportChart> :
                             <ReportInfo></ReportInfo>

--- a/src/pages/Report.jsx
+++ b/src/pages/Report.jsx
@@ -73,7 +73,7 @@ const Report = (props) => {
     )
 
     return (
-        <div className="flex absolute w-screen h-screen justify-center">
+        <div className="flex absolute w-screen h-screen justify-center pb-24">
             <img src="/serratus.jpg" alt="serratus mountain" className="hidden sm:block opacity-75 sm:fixed" style={{ objectFit: 'cover', minWidth: '100vh', minHeight: '100vh' }} />
             <div className="flex flex-col justify-center items-center w-full z-10 rounded-lg p-1
                 sm:shadow-2xl


### PR DESCRIPTION
- Add padding to center report page content