### PR TITLE
Home: replace <text> with <span>

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -21,8 +21,8 @@ const Home = () => {
                         {searchIcon} Discover
                     </NavLink>
                     <h3 className="inline text-lg font-thin my-5">
-                        <text className="font-normal">3,837,755</text> runs processed<text className="border-l border-white mx-2" />
-                        <text className="font-normal">5,620,086,903,602,832</text> nucleotides
+                        <span className="font-normal">3,837,755</span> runs processed<span className="border-l border-white mx-2" />
+                        <span className="font-normal">5,620,086,903,602,832</span> nucleotides
                     </h3>
                 </div>
             </div>


### PR DESCRIPTION
Was stuck in D3 mode so I used `<text>` which triggers a console warning in development mode:

> Warning: The tag <text> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.

Changed to the more appropriate `<span>`.