### PR TITLE
Feature/lohrd/paginator

### DIFF
--- a/src/SDK/DataSdk.jsx
+++ b/src/SDK/DataSdk.jsx
@@ -10,13 +10,14 @@ export default class DataSdk {
         return response.data
     }
 
-    async fetchSraHitsByAccession(genbankAccession, pageNumber) {
-        const response = await axios.get(`${this.baseUrl}/api/genbank/get-runs/${genbankAccession}?page=${pageNumber}`);
+    async fetchSraHitsByAccession(genbankAccession, pageNumber, itemsPerPage) {
+
+        const response = await axios.get(`${this.baseUrl}/api/genbank/get-runs/${genbankAccession}?page=${pageNumber}&itemsPerPage=${itemsPerPage}`);
         return response.data;
     }
 
-    async fetchSraHitsByFamily(familyName, pageNumber) {
-        const response = await axios.get(`${this.baseUrl}/api/family/get-runs/${familyName}?page=${pageNumber}`);
+    async fetchSraHitsByFamily(familyName, pageNumber, itemsPerPage) {
+        const response = await axios.get(`${this.baseUrl}/api/family/get-runs/${familyName}?page=${pageNumber}&itemsPerPage=${itemsPerPage}`);
         return response.data;
     }
 

--- a/src/SDK/DataSdk.jsx
+++ b/src/SDK/DataSdk.jsx
@@ -11,7 +11,6 @@ export default class DataSdk {
     }
 
     async fetchSraHitsByAccession(genbankAccession, pageNumber, itemsPerPage) {
-
         const response = await axios.get(`${this.baseUrl}/api/genbank/get-runs/${genbankAccession}?page=${pageNumber}&itemsPerPage=${itemsPerPage}`);
         return response.data;
     }

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -1,27 +1,58 @@
 import React from "react";
 
 const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages} ) => {
-  const buttonClasses = "bg-gray-300 hover:bg-gray-500 mx-2 py-1 px-4 rounded inline-flex items-center";
-  const invisibleButton = "invisible bg-gray-300 hover:bg-gray-500 mx-2 py-1 px-4 rounded inline-flex items-center";
+  const visibleButton = "bg-gray-300 hover:bg-gray-500 mx-2 py-1 px-4 rounded inline-flex items-center";
+  const invisibleButton = "invisible" + visibleButton;
+  const centerButtons = "flex flex-row justify-center items-center";
+
+  const nextPage = () => setPageNumber(pageNumber + 1);
   
+  const prevPage = () => setPageNumber(pageNumber - 1);
+  
+  const FirstPagePaginator = () => {
+    return (
+      <div>
+        <button className={invisibleButton}></button>
+          Page {pageNumber} out of ...
+        <button className={visibleButton} onClick={nextPage}>next</button>
+      </div>
+    )
+  }
+
+  const MiddlePagePaginator = () => {
+    return (
+      <div> 
+        <button className={visibleButton} onClick={prevPage}>prev</button>         
+          Page {pageNumber} out of {numberOfPages}
+        <button className={visibleButton} onClick={nextPage}>next</button>
+      </div>
+    )
+  }
+
+  const LastPagePaginator = () => {
+    return ( 
+      <div> 
+        <button className={visibleButton} onClick={prevPage}>prev</button>
+          Page {pageNumber} out of {numberOfPages}
+        <button className={invisibleButton}></button>
+      </div> 
+    )
+  }
+
   React.useEffect(() => {
     getNumberOfPages();
   }, [pageNumber]);
 
   return (
-    <div className="flex flex-row justify-center items-center">
-        {pageNumber == 1 
-        ? <div>
-            <button className={invisibleButton} onClick={() => setPageNumber(pageNumber - 1)}>prev</button>
-            Page {pageNumber} out of ...
-            <button className={buttonClasses} onClick={() => setPageNumber(pageNumber + 1)}>next</button>
-          </div> 
-        : <div>
-            <button className={buttonClasses} onClick={() => setPageNumber(pageNumber - 1)}>prev</button>
-            Page {pageNumber} out of {numberOfPages}
-            <button className={buttonClasses} onClick={() => setPageNumber(pageNumber + 1)}>next</button>
-          </div> 
-          }
+    <div className={centerButtons}>
+      {pageNumber == 1 ? 
+        <FirstPagePaginator/>
+      : <div className={centerButtons}>
+          {pageNumber == numberOfPages ?
+            <LastPagePaginator/>
+            : <MiddlePagePaginator/>}
+        </div> 
+      }
     </div>
   )
 }

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 
-const Paginator = ( {pageNumber, setPageNumber} ) => {
+const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages} ) => {
   const buttonClasses = "bg-gray-300 hover:bg-gray-500 mx-2 py-1 px-4 rounded inline-flex items-center";
   const invisibleButton = "invisible bg-gray-300 hover:bg-gray-500 mx-2 py-1 px-4 rounded inline-flex items-center";
+  
+  React.useEffect(() => {
+    getNumberOfPages();
+  }, [pageNumber]);
+
   return (
     <div className="flex flex-row justify-center items-center">
         {pageNumber == 1 

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -13,17 +13,17 @@ const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages}
         {pageNumber == 1 
         ? <div>
             <button className={invisibleButton} onClick={() => setPageNumber(pageNumber - 1)}>prev</button>
-            {pageNumber}
+            Page {pageNumber} out of ...
             <button className={buttonClasses} onClick={() => setPageNumber(pageNumber + 1)}>next</button>
           </div> 
         : <div>
             <button className={buttonClasses} onClick={() => setPageNumber(pageNumber - 1)}>prev</button>
-            {pageNumber}
+            Page {pageNumber} out of {numberOfPages}
             <button className={buttonClasses} onClick={() => setPageNumber(pageNumber + 1)}>next</button>
           </div> 
           }
     </div>
-    )
+  )
 }
 
 export default Paginator;

--- a/src/components/QueryResult.jsx
+++ b/src/components/QueryResult.jsx
@@ -33,7 +33,7 @@ const QueryResult = (props) => {
             case "family":
                 columns = ["score", "pctId", "aln"];
                 props.dataPromise.then((data) => {
-                    data = data.slice(0, 20);
+                    data = data.familySections.slice(0, 20);
                     let hasResults = data && data.length !== 0;
                     callback = getResultsCallback(drawQueryResults, columns, hasResults);
                     callback(data);
@@ -45,7 +45,7 @@ const QueryResult = (props) => {
             case "genbank":
                 columns = ["cvgPct", "pctId", "aln"];
                 props.dataPromise.then((data) => {
-                    data = data.slice(0, 20);
+                    data = data.accessionSections.slice(0, 20);
                     let hasResults = data && data.length !== 0;
                     callback = getResultsCallback(drawQueryResults, columns, hasResults);
                     callback(data);

--- a/src/components/QueryResult.jsx
+++ b/src/components/QueryResult.jsx
@@ -33,7 +33,7 @@ const QueryResult = (props) => {
             case "family":
                 columns = ["score", "pctId", "aln"];
                 props.dataPromise.then((data) => {
-                    data = data.items.slice(0, 20);
+                    data = data.items;
                     let hasResults = data && data.length !== 0;
                     callback = getResultsCallback(drawQueryResults, columns, hasResults);
                     callback(data);
@@ -45,7 +45,7 @@ const QueryResult = (props) => {
             case "genbank":
                 columns = ["cvgPct", "pctId", "aln"];
                 props.dataPromise.then((data) => {
-                    data = data.items.slice(0, 20);
+                    data = data.items;
                     let hasResults = data && data.length !== 0;
                     callback = getResultsCallback(drawQueryResults, columns, hasResults);
                     callback(data);

--- a/src/components/QueryResult.jsx
+++ b/src/components/QueryResult.jsx
@@ -33,7 +33,7 @@ const QueryResult = (props) => {
             case "family":
                 columns = ["score", "pctId", "aln"];
                 props.dataPromise.then((data) => {
-                    data = data.familySections.slice(0, 20);
+                    data = data.items.slice(0, 20);
                     let hasResults = data && data.length !== 0;
                     callback = getResultsCallback(drawQueryResults, columns, hasResults);
                     callback(data);
@@ -45,7 +45,7 @@ const QueryResult = (props) => {
             case "genbank":
                 columns = ["cvgPct", "pctId", "aln"];
                 props.dataPromise.then((data) => {
-                    data = data.accessionSections.slice(0, 20);
+                    data = data.items.slice(0, 20);
                     let hasResults = data && data.length !== 0;
                     callback = getResultsCallback(drawQueryResults, columns, hasResults);
                     callback(data);

--- a/src/helpers/QueryPageHelpers.jsx
+++ b/src/helpers/QueryPageHelpers.jsx
@@ -106,12 +106,12 @@ const getTitle = async (type, value, valueCorrected) => {
     return title;
 }
 
-const getDataPromise = (type, value, page) => {
+const getDataPromise = (type, value, page, itemsPerPage) => {
     switch (type) {
         case "family":
-            return dataSdk.fetchSraHitsByFamily(value, page);
+            return dataSdk.fetchSraHitsByFamily(value, page, itemsPerPage);
         case "genbank":
-            return dataSdk.fetchSraHitsByAccession(value, page);
+            return dataSdk.fetchSraHitsByAccession(value, page, itemsPerPage);
         case "run":
             return dataSdk.fetchSraRun(value, page);
         default:

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -47,7 +47,8 @@ const Query = (props) => {
     const [placeholderText, setPlaceholderText] = React.useState(getPlaceholder(queryTypeFromParam));
     const [pageTitle, setPageTitle] = React.useState();
     const [pageNumber, setPageNumber] = React.useState(1);
-    const [numberOfPages, setNumberOfPages] = React.useState(0)
+    const [numberOfPages, setNumberOfPages] = React.useState(0);
+    const [itemsPerPage, setItemsPerPage] = React.useState(20);
     const [queryValueCorrected, setQueryValueCorrected] = React.useState(queryValueStatic);
     const [dataPromise, setDataPromise] = React.useState();
     
@@ -99,7 +100,7 @@ const Query = (props) => {
             return;
         }
         console.log(`Loading query result page for ${queryTypeStatic}=${queryValueStatic}.`);
-        setDataPromise(getDataPromise(queryTypeStatic, queryValueStatic, pageNumber));
+        setDataPromise(getDataPromise(queryTypeStatic, queryValueStatic, pageNumber, itemsPerPage));
         // check for AMR accession
         console.log(dataPromise);
         let valueCorrected = queryValueStatic;
@@ -112,7 +113,7 @@ const Query = (props) => {
             }
         }
         getTitle(queryTypeStatic, queryValueStatic, valueCorrected).then(setPageTitle);
-        getNumberOfPages();
+        setItemsPerPage(20);
     }, [queryTypeStatic, queryValueStatic, pageNumber]);
 
     let headTags = (

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -87,6 +87,12 @@ const Query = (props) => {
         setPageNumber(1);
     }
 
+    async function getNumberOfPages() {
+        if (!dataPromise) return;
+        var data = await dataPromise;
+        setNumberOfPages(data.numberOfPages);
+    }
+
     React.useEffect(() => {
         if (!queryValueStatic) {
             return;

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -170,7 +170,7 @@ const Query = (props) => {
                                 <QueryResult type={queryTypeStatic} value={queryValueStatic} dataPromise={dataPromise} />
                              :
                              <div>
-                                <Paginator pageNumber={pageNumber} setPageNumber={setPageNumber} />
+                                <Paginator pageNumber={pageNumber} setPageNumber={setPageNumber} numberOfPages={numberOfPages} getNumberOfPages={getNumberOfPages}/>
                                 <QueryResult type={queryTypeStatic} value={queryValueStatic} dataPromise={dataPromise} />
                             </div>
                             }

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -112,6 +112,7 @@ const Query = (props) => {
             }
         }
         getTitle(queryTypeStatic, queryValueStatic, valueCorrected).then(setPageTitle);
+        getNumberOfPages();
     }, [queryTypeStatic, queryValueStatic, pageNumber]);
 
     let headTags = (

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -47,6 +47,7 @@ const Query = (props) => {
     const [placeholderText, setPlaceholderText] = React.useState(getPlaceholder(queryTypeFromParam));
     const [pageTitle, setPageTitle] = React.useState();
     const [pageNumber, setPageNumber] = React.useState(1);
+    const [numberOfPages, setNumberOfPages] = React.useState(0)
     const [queryValueCorrected, setQueryValueCorrected] = React.useState(queryValueStatic);
     const [dataPromise, setDataPromise] = React.useState();
     


### PR DESCRIPTION
This PR updates the API call on the frontend to match the new data coming from the backend for pagination. 
- Need to fix UI still
- Need to come up with a better way to immediately get the number of pages rather than waiting on the promise to be consumed on the call for the second page. For now, '...' is a place holder for the total number of pages while on page 1.

Family Example:
https://paginator.serratus.io/query?family=Coronaviridae

GenBank Example:
https://paginator.serratus.io/query?genbank=EU769558.1