### PR TITLE
Fix/lohrd/paginator

### DIFF
--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -22,6 +22,16 @@ const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
     })
   }
   
+  const OnePagePaginator = () => {
+    return (
+      <div>
+        <button className={invisibleButton}></button>
+          Page 1 out of 1
+        <button className={invisibleButton} onClick={nextPage}>next</button>
+    </div>
+    )
+  }
+
   const FirstPagePaginator = () => {
     return (
       <div>
@@ -56,10 +66,12 @@ const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
     return (
       <div className={centerButtons}>
       {pageNumber == 1 ? 
-        <FirstPagePaginator/>
-      : <div className={centerButtons}>
-          {pageNumber == numPages ?
-            <LastPagePaginator/>
+        numPages == 1 ? 
+          <OnePagePaginator/> : 
+            <FirstPagePaginator/>
+          : <div className={centerButtons}>
+            {pageNumber == numPages ?
+              <LastPagePaginator/>
             : <MiddlePagePaginator/>}
         </div> 
       }

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -21,63 +21,6 @@ const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
       setNumPages(data);
     })
   }
-  
-  const OnePagePaginator = () => {
-    return (
-      <div>
-        <button className={invisibleButton}></button>
-          Page 1 out of 1
-        <button className={invisibleButton} onClick={nextPage}>next</button>
-    </div>
-    )
-  }
-
-  const FirstPagePaginator = () => {
-    return (
-      <div>
-        <button className={invisibleButton}></button>
-          Page {pageNumber} out of {numPages}
-        <button className={visibleButton} onClick={nextPage}>next</button>
-      </div>
-    )
-  }
-
-  const MiddlePagePaginator = () => {
-    return (
-      <div> 
-        <button className={visibleButton} onClick={prevPage}>prev</button>         
-          Page {pageNumber} out of {numPages}
-        <button className={visibleButton} onClick={nextPage}>next</button>
-      </div>
-    )
-  }
-
-  const LastPagePaginator = () => {
-    return ( 
-      <div> 
-        <button className={visibleButton} onClick={prevPage}>prev</button>
-          Page {pageNumber} out of {numPages}
-        <button className={invisibleButton}></button>
-      </div> 
-    )
-  }
-
-  const FullPaginator = () => {
-    return (
-      <div className={centerButtons}>
-      {pageNumber == 1 ? 
-        numPages == 1 ? 
-          <OnePagePaginator/> : 
-            <FirstPagePaginator/>
-          : <div className={centerButtons}>
-            {pageNumber == numPages ?
-              <LastPagePaginator/>
-            : <MiddlePagePaginator/>}
-        </div> 
-      }
-    </div>
-    )
-}
 
   React.useEffect(() => {
     if(!dataPromise) return;
@@ -85,10 +28,19 @@ const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
   }, [pageNumber, numPages, dataPromise]);
 
   return (
-    <div> 
-      {loading ? <div></div> : <FullPaginator/> }
-    </div>
-  )
+      !loading &&
+      <div className={centerButtons}>
+        {pageNumber === 1 ?
+          <button className={invisibleButton}></button>
+          : <button className={visibleButton} onClick={prevPage}>prev</button>
+        }
+            Page {pageNumber} out of {numPages}
+        {pageNumber === numPages ?
+          <button className={invisibleButton}></button>
+          : <button className={visibleButton} onClick={nextPage}>next</button>
+        }
+      </div>
+    )
 }
 
 export default Paginator;

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -13,33 +13,33 @@ const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
   const prevPage = () => setPageNumber(pageNumber - 1);
 
   const readDataPromise = async (dataPromise) => {
-	if (!dataPromise) return;
-	dataPromise.then((data) => {
-	  data = data.numberOfPages;
-	  setLoading(false);
-	  setNumPages(data);
-	})
+    if (!dataPromise) return;
+    dataPromise.then((data) => {
+      data = data.numberOfPages;
+      setLoading(false);
+      setNumPages(data);
+    })
   }
 
   React.useEffect(() => {
-	if(!dataPromise) return;
-	readDataPromise(dataPromise);
+    if(!dataPromise) return;
+    readDataPromise(dataPromise);
   }, [pageNumber, numPages, dataPromise]);
 
   return (
-	!loading &&
-	<div className={centerButtons}>
-	  {pageNumber === 1 ?
-		<button className={invisibleButton}></button>
-		: <button className={visibleButton} onClick={prevPage}>prev</button>
-	  }
-		  Page {pageNumber} out of {numPages}
-	  {pageNumber === numPages ?
-		<button className={invisibleButton}></button>
-		: <button className={visibleButton} onClick={nextPage}>next</button>
-	  }
-	</div>
-  )
+      !loading &&
+      <div className={centerButtons}>
+        {pageNumber === 1 ?
+          <button className={invisibleButton}></button>
+          : <button className={visibleButton} onClick={prevPage}>prev</button>
+        }
+            Page {pageNumber} out of {numPages}
+        {pageNumber === numPages ?
+          <button className={invisibleButton}></button>
+          : <button className={visibleButton} onClick={nextPage}>next</button>
+        }
+      </div>
+    )
 }
 
 export default Paginator;

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { data } from "autoprefixer";
 
 const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
   const [numPages, setNumPages] = React.useState();

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -14,33 +14,33 @@ const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
   const prevPage = () => setPageNumber(pageNumber - 1);
 
   const readDataPromise = async (dataPromise) => {
-    if (!dataPromise) return;
-    dataPromise.then((data) => {
-      data = data.numberOfPages;
-      setLoading(false);
-      setNumPages(data);
-    })
+	if (!dataPromise) return;
+	dataPromise.then((data) => {
+	  data = data.numberOfPages;
+	  setLoading(false);
+	  setNumPages(data);
+	})
   }
 
   React.useEffect(() => {
-    if(!dataPromise) return;
-    readDataPromise(dataPromise);
+	if(!dataPromise) return;
+	readDataPromise(dataPromise);
   }, [pageNumber, numPages, dataPromise]);
 
   return (
-      !loading &&
-      <div className={centerButtons}>
-        {pageNumber === 1 ?
-          <button className={invisibleButton}></button>
-          : <button className={visibleButton} onClick={prevPage}>prev</button>
-        }
-            Page {pageNumber} out of {numPages}
-        {pageNumber === numPages ?
-          <button className={invisibleButton}></button>
-          : <button className={visibleButton} onClick={nextPage}>next</button>
-        }
-      </div>
-    )
+	!loading &&
+	<div className={centerButtons}>
+	  {pageNumber === 1 ?
+		<button className={invisibleButton}></button>
+		: <button className={visibleButton} onClick={prevPage}>prev</button>
+	  }
+		  Page {pageNumber} out of {numPages}
+	  {pageNumber === numPages ?
+		<button className={invisibleButton}></button>
+		: <button className={visibleButton} onClick={nextPage}>next</button>
+	  }
+	</div>
+  )
 }
 
 export default Paginator;

--- a/src/components/Paginator.jsx
+++ b/src/components/Paginator.jsx
@@ -1,6 +1,10 @@
 import React from "react";
+import { data } from "autoprefixer";
 
-const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages} ) => {
+const Paginator = ( {pageNumber, setPageNumber, dataPromise} ) => {
+  const [numPages, setNumPages] = React.useState();
+  const [loading, setLoading] = React.useState(true);
+  
   const visibleButton = "bg-gray-300 hover:bg-gray-500 mx-2 py-1 px-4 rounded inline-flex items-center";
   const invisibleButton = "invisible" + visibleButton;
   const centerButtons = "flex flex-row justify-center items-center";
@@ -8,12 +12,21 @@ const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages}
   const nextPage = () => setPageNumber(pageNumber + 1);
   
   const prevPage = () => setPageNumber(pageNumber - 1);
+
+  const readDataPromise = async (dataPromise) => {
+    if (!dataPromise) return;
+    dataPromise.then((data) => {
+      data = data.numberOfPages;
+      setLoading(false);
+      setNumPages(data);
+    })
+  }
   
   const FirstPagePaginator = () => {
     return (
       <div>
         <button className={invisibleButton}></button>
-          Page {pageNumber} out of ...
+          Page {pageNumber} out of {numPages}
         <button className={visibleButton} onClick={nextPage}>next</button>
       </div>
     )
@@ -23,7 +36,7 @@ const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages}
     return (
       <div> 
         <button className={visibleButton} onClick={prevPage}>prev</button>         
-          Page {pageNumber} out of {numberOfPages}
+          Page {pageNumber} out of {numPages}
         <button className={visibleButton} onClick={nextPage}>next</button>
       </div>
     )
@@ -33,26 +46,35 @@ const Paginator = ( {pageNumber, setPageNumber, numberOfPages, getNumberOfPages}
     return ( 
       <div> 
         <button className={visibleButton} onClick={prevPage}>prev</button>
-          Page {pageNumber} out of {numberOfPages}
+          Page {pageNumber} out of {numPages}
         <button className={invisibleButton}></button>
       </div> 
     )
   }
 
-  React.useEffect(() => {
-    getNumberOfPages();
-  }, [pageNumber]);
-
-  return (
-    <div className={centerButtons}>
+  const FullPaginator = () => {
+    return (
+      <div className={centerButtons}>
       {pageNumber == 1 ? 
         <FirstPagePaginator/>
       : <div className={centerButtons}>
-          {pageNumber == numberOfPages ?
+          {pageNumber == numPages ?
             <LastPagePaginator/>
             : <MiddlePagePaginator/>}
         </div> 
       }
+    </div>
+    )
+}
+
+  React.useEffect(() => {
+    if(!dataPromise) return;
+    readDataPromise(dataPromise);
+  }, [pageNumber, numPages, dataPromise]);
+
+  return (
+    <div> 
+      {loading ? <div></div> : <FullPaginator/> }
     </div>
   )
 }

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -48,7 +48,6 @@ const Query = (props) => {
     const [placeholderText, setPlaceholderText] = React.useState(getPlaceholder(queryTypeFromParam));
     const [pageTitle, setPageTitle] = React.useState();
     const [pageNumber, setPageNumber] = React.useState(1);
-    const [numberOfPages, setNumberOfPages] = React.useState(0);
     const [itemsPerPage, setItemsPerPage] = React.useState(20);
     const [queryValueCorrected, setQueryValueCorrected] = React.useState(queryValueStatic);
     const [dataPromise, setDataPromise] = React.useState();
@@ -88,12 +87,6 @@ const Query = (props) => {
         setPlaceholderText(getPlaceholder(queryType));
         setSearchType(queryType);
         setPageNumber(1);
-    }
-
-    async function getNumberOfPages() {
-        if (!dataPromise) return;
-        var data = await dataPromise;
-        setNumberOfPages(data.numberOfPages);
     }
 
     React.useEffect(() => {
@@ -176,7 +169,6 @@ const Query = (props) => {
                                 <QueryResult type={queryTypeStatic} value={queryValueStatic} dataPromise={dataPromise} />
                              :
                              <div>
-                                <Paginator pageNumber={pageNumber} setPageNumber={setPageNumber} numberOfPages={numberOfPages} getNumberOfPages={getNumberOfPages}/>
                                 <Paginator pageNumber={pageNumber} setPageNumber={setPageNumber} dataPromise={dataPromise}/>
                                 <QueryResult type={queryTypeStatic} value={queryValueStatic} dataPromise={dataPromise} />
                             </div>

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -177,6 +177,7 @@ const Query = (props) => {
                              :
                              <div>
                                 <Paginator pageNumber={pageNumber} setPageNumber={setPageNumber} numberOfPages={numberOfPages} getNumberOfPages={getNumberOfPages}/>
+                                <Paginator pageNumber={pageNumber} setPageNumber={setPageNumber} dataPromise={dataPromise}/>
                                 <QueryResult type={queryTypeStatic} value={queryValueStatic} dataPromise={dataPromise} />
                             </div>
                             }


### PR DESCRIPTION
This pull request addresses issue #75 

- Changed '..,' to the actual number of pages present on first load

- Attempted Fix: 'for queries with a result set n<20, it should just display "Page 1 of 1" with no buttons.'

- Attempted Fix: '"next" button should be invisible on last page'

- Need to add the query filtering page to dev to test both above attempted fixes, but they both currently work for genbank/family searches with no queries.

Live Preview: https://fix-lohrd-paginator.d1w6d75be7tofa.amplifyapp.com/query?genbank=EU769558.1
