### PR TITLE
Explore chart: match look of figure in paper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4508,6 +4508,17 @@
         "d3-transition": "1",
         "d3-voronoi": "1",
         "d3-zoom": "1"
+      },
+      "dependencies": {
+        "d3-scale-chromatic": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+          "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+          "requires": {
+            "d3-color": "1",
+            "d3-interpolate": "1"
+          }
+        }
       }
     },
     "d3-array": {
@@ -4667,12 +4678,12 @@
       }
     },
     "d3-scale-chromatic": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
-      "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
       "requires": {
-        "d3-color": "1",
-        "d3-interpolate": "1"
+        "d3-color": "1 - 2",
+        "d3-interpolate": "1 - 2"
       }
     },
     "d3-selection": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
     "d3": "^5.16.0",
+    "d3-scale-chromatic": "^2.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-dropdown-select": "4.4.2",

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -111,7 +111,9 @@ export const renderChart = (data, xDomain, zDomain) => {
         .enter()
         .append("g")
         .attr("label", d => `z-${d.key}`)
-        .attr("fill", d => colorScale(d.key));
+        .attr("fill", d => colorScale(d.key))
+        .attr("stroke", d => colorScale(d.key))
+        .attr("stroke-width", "0.1");
 
     chartZRects.selectAll("rect")
         .data(d => d)

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -94,15 +94,7 @@ export const renderChart = (data, xDomain, zDomain) => {
         .attr("opacity", 1)
         .text(xLabel);
 
-    var dataFiltered = familyData.filter((d) => {
-        return (
-            (d[xColumn] >= xDomain[0]) &&
-            (d[xColumn] <= xDomain[1]) &&
-            (d[zColumn] >= zDomain[0]) &&
-            (d[zColumn] <= zDomain[1])
-        );
-    });
-    setDataByZStackFiltered(dataFiltered);
+    filterAndSetStackData();
 
     var rectsG = chartG.append("g").attr("label", "stack-rects");
 
@@ -128,7 +120,7 @@ export const renderChart = (data, xDomain, zDomain) => {
 export const updateData = (data) => {
     console.log('updateData()');
     familyData = data;
-    setDataByZStackFiltered(data);
+    filterAndSetStackData(data);
 }
 
 export const updateXLims = (begin, end) => {
@@ -167,26 +159,7 @@ export const updateYLims = (transitionDuration = 0) => {
 
 const updateStacks = (transitionDuration = 0) => {
     console.log('updateStacks()');
-    var dataFiltered = familyData.filter((d) => {
-        return (
-            (d[xColumn] >= xLims[0]) &&
-            (d[xColumn] <= xLims[1]) &&
-            (d[zColumn] >= zLims[0]) &&
-            (d[zColumn] <= zLims[1])
-        );
-    });
-
-    setDataByZStackFiltered(dataFiltered);
-
-    // chartRects.remove()
-
-    // chartRects = chartG.selectAll("g")
-    //     .data(dataByZStackFiltered)
-    //     .enter()
-    //     .append("g")
-    //     .attr("id", d => d.key)
-    //     .attr("fill", d => "black");
-
+    filterAndSetStackData();
     chartZRects.data(dataByZStackFiltered);
     chartZRects.selectAll("rect").data(d => d).transition().duration(transitionDuration)
         .attr("x", (d, i) => xScale(d.data.key))
@@ -195,7 +168,15 @@ const updateStacks = (transitionDuration = 0) => {
         .attr("width", xScale.bandwidth());
 }
 
-const setDataByZStackFiltered = (dataFiltered) => {
+const filterAndSetStackData = () => {
+    var dataFiltered = familyData.filter((d) => {
+        return (
+            (d[xColumn] >= xLims[0]) &&
+            (d[xColumn] <= xLims[1]) &&
+            (d[zColumn] >= zLims[0]) &&
+            (d[zColumn] <= zLims[1])
+        );
+    });
     var dataByX = d3.nest()
         .key((d) => d[xColumn])
         .entries(dataFiltered);

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -64,8 +64,7 @@ export const renderChart = (data, xDomain, zDomain) => {
     yScale = d3.scaleLinear()
         .range([chartHeight, 0]);
     yScale.domain(yLims).nice();
-    var colorScale = d3.scaleLinear()
-        .range(zColorLims);
+    var colorScale = d3.scaleSequential(d3.interpolateViridis);
     colorScale.domain(zDomain);
 
     xAxis = chartG.append("g")

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -104,7 +104,9 @@ export const renderChart = (data, xDomain, zDomain) => {
     });
     setDataByZStackFiltered(dataFiltered);
 
-    chartZRects = chartG.selectAll("g")
+    var rectsG = chartG.append("g").attr("label", "stack-rects");
+
+    chartZRects = rectsG.selectAll("g")
         .data(dataByZStackFiltered)
         .enter()
         .append("g")

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -180,6 +180,15 @@ const filterAndSetStackData = () => {
     var dataByX = d3.nest()
         .key((d) => d[xColumn])
         .entries(dataFiltered);
+    // make entry for each x
+    var xKeys = dataByX.reduce((set, d) => { set.add(d.key); return set; }, new Set());
+    xLimValues.forEach(xVal => {
+        var xValString = xVal.toString();
+        if (!xKeys.has(xValString)) {
+            dataByX.push({key: xValString, values: []})
+        }
+    });
+    // make entry for each z
     dataByX.forEach((d) => {
         d.values = d.values.reduce((collection, d) => {
             collection[d[zColumn]] = d[yColumn];

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -26,7 +26,6 @@ var familyData;
 // auto-computed
 var yLims = [0, 0];  // computed after family data loaded
 var xLimValues; // all x values
-var zLimValues;
 var zDomainValues;  // all possible z values
 
 // D3 objects
@@ -41,8 +40,7 @@ export const renderChart = (data, xDomain, zDomain) => {
     familyData = data;
     setXLims(xDomain);
     zLims = zDomain;
-    zDomainValues = getAllValues(...zLims);
-    zLimValues = getAllValues(...zLims);
+    zDomainValues = getAllValues(...zDomain);
 
     var chartWidth = 300;
     var chartHeight = 150;
@@ -148,7 +146,6 @@ export const updateZLims = (begin, end) => {
     }
     console.log(`updateZLims(${begin},${end})`);
     zLims = [begin, end];
-    zLimValues = getAllValues(...zLims);
     updateStacks();
 }
 

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -14,7 +14,6 @@ export default () => {
 const xColumn = "pctid";
 const yColumn = "n";
 const zColumn = "score";
-const zColorLims = ["#3d5088", "#fce540"];
 const xLabel = "% Identity";
 const zLabel = "Hit count";
 
@@ -122,7 +121,7 @@ export const updateData = (data) => {
 }
 
 export const updateXLims = (begin, end) => {
-    if (xLims[0] == begin && xLims[1] == end) {
+    if (xLims[0] === begin && xLims[1] === end) {
         return;
     }
     setXLims([begin, end]);
@@ -132,7 +131,7 @@ export const updateXLims = (begin, end) => {
 }
 
 export const updateZLims = (begin, end) => {
-    if (zLims[0] == begin && zLims[1] == end) {
+    if (zLims[0] === begin && zLims[1] === end) {
         return;
     }
     zLims = [begin, end];

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -118,7 +118,6 @@ export const renderChart = (data, xDomain, zDomain) => {
 }
 
 export const updateData = (data) => {
-    console.log('updateData()');
     familyData = data;
     filterAndSetStackData(data);
 }
@@ -127,7 +126,6 @@ export const updateXLims = (begin, end) => {
     if (xLims[0] == begin && xLims[1] == end) {
         return;
     }
-    console.log(`updateXLims(${begin},${end})`);
     setXLims([begin, end]);
     xScale.domain(xLimValues);
     xAxis.call(d3.axisBottom(xScale).tickValues(getXTicks()));
@@ -138,13 +136,11 @@ export const updateZLims = (begin, end) => {
     if (zLims[0] == begin && zLims[1] == end) {
         return;
     }
-    console.log(`updateZLims(${begin},${end})`);
     zLims = [begin, end];
     updateStacks();
 }
 
 export const updateYLims = (transitionDuration = 0) => {
-    console.log('updateYLims()');
     var maxDataY = 1.2 * d3.max(dataByZStackFiltered.map((d) => {
         return d3.max(d, (innerD) => {
             return innerD[1];
@@ -158,7 +154,6 @@ export const updateYLims = (transitionDuration = 0) => {
 }
 
 const updateStacks = (transitionDuration = 0) => {
-    console.log('updateStacks()');
     filterAndSetStackData();
     chartZRects.data(dataByZStackFiltered);
     chartZRects.selectAll("rect").data(d => d).transition().duration(transitionDuration)

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -144,7 +144,7 @@ export const updateYLims = (transitionDuration = 0) => {
             return innerD[1];
         });
     }));
-    if (isNaN(maxDataY)) maxDataY = 10;  // set limits even if no data
+    if (isNaN(maxDataY) || maxDataY < 10) maxDataY = 10;  // set min upper limit of 10
     yLims = [0, maxDataY];
     yScale.domain(yLims).nice();
     yAxis.transition().duration(transitionDuration).call(d3.axisLeft(yScale).ticks(5));

--- a/src/components/FilterSlider.jsx
+++ b/src/components/FilterSlider.jsx
@@ -14,7 +14,7 @@ export default (props) => {
     // directly fetch initial .current
     const id = useRef(props.id).current;
     const sliderDomain = useRef(props.sliderDomain).current;
-    const colorGradientLims = useRef(props.colorGradientLims).current;
+    const linearGradientString = useRef(props.linearGradientString).current;
 
     useEffect(() => {
         const updateLims = (begin, end) => {
@@ -27,8 +27,8 @@ export default (props) => {
             var sliderDiv = d3.select(`#${id}`);
             slider.current = createD3RangeSlider(d3, sliderDomain[0], sliderDomain[1], sliderDiv);
             slider.current.onChange((range) => updateLims(range.begin, range.end));
-            if (colorGradientLims) {
-                var colorGradient = `background-image: linear-gradient(to right, ${colorGradientLims[0]} , ${colorGradientLims[1]});`;
+            if (linearGradientString) {
+                var colorGradient = `background-image: ${linearGradientString};`;
                 var newSliderDivStyle = sliderDiv.attr("style") + colorGradient;
                 sliderDiv.attr("style", newSliderDivStyle)
                 sliderDiv.select(".slider-container")
@@ -44,7 +44,7 @@ export default (props) => {
         };
 
         drawSlider();
-    }, [id, sliderDomain, colorGradientLims, props.sliderLimsRef]);
+    }, [id, sliderDomain, linearGradientString, props.sliderLimsRef]);
 
     useEffect(() => {
         slider.current && slider.current.range(...props.sliderLimsRef.current);

--- a/src/helpers/common.jsx
+++ b/src/helpers/common.jsx
@@ -13,3 +13,6 @@ export const githubIcon = (<svg className="inline fill-current w-4 h-4 mb-1" xml
 
 // components
 export const ExternalLink = (props) => {return (<a {...props} target="_blank" rel="noopener noreferrer">{props.children}</a>)}
+
+// color palettes
+export const viridisCssGradient = "linear-gradient(90deg, #440154, #482475, #414487, #355f8d, #2a788e, #21908d, #22a884, #42be71, #7ad151, #bddf26, #fce640)" // slight modification of https://bennettfeely.com/cssscales/#viridis

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -34,12 +34,12 @@ export default () => {
         var data = allFamilyData[family];
         if (!chartRendered.current) {
             renderChart(data, identityDomain, coverageDomain);
+            updateZ();
             chartRendered.current = true;
         }
         else {
             updateData(data);
         }
-        updateZ();
         updateYLims();
     }, [family]);
 

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -11,6 +11,7 @@ import ExploreChart, {
     updateZLims
 } from '../components/ExploreChart';
 import {
+    viridisCssGradient,
     switchSize,
     classesBoxBorder
 } from '../helpers/common';
@@ -93,7 +94,7 @@ export default () => {
                         <FilterSlider id="sliderCoverage"
                             sliderDomain={coverageDomain}
                             sliderLimsRef={sliderCoverageLimsRef}
-                            colorGradientLims={["#3d5088", "#fce540"]}
+                            linearGradientString={viridisCssGradient}
                             onChange={updateZ}
                             onTouchEnd={updateY} />
                     </div>

--- a/src/pages/Query.jsx
+++ b/src/pages/Query.jsx
@@ -19,6 +19,7 @@ import {
     InputOption
 } from "../helpers/QueryPageHelpers";
 import {
+    viridisCssGradient,
     switchSize,
     classesBoxBorder
 } from '../helpers/common';
@@ -179,7 +180,7 @@ const Query = (props) => {
                                 <FilterSlider id="sliderCoverage"
                                     sliderDomain={coverageDomain}
                                     sliderLimsRef={sliderCoverageLimsRef}
-                                    colorGradientLims={["#3d5088", "#fce540"]} />
+                                    linearGradientString={viridisCssGradient} />
                             </div>
                         </div>
                     }


### PR DESCRIPTION
This pull request will close #62 and close #63.

Live preview: https://dev-explore-histogram.serratus.io/explore

**Summary of changes**
- Convert Explore chart to histogram
    - Note: performance is noticeably slower than the current area chart. D3 has to render several rectangles per color rather than one continuous shape.
- Use viridis color scale for score/coverage value domain

TODO
- [x] first 15 score (z) values aren't being rendered. need to fix this
- [x] fix y-axis scaling delays when changing between families
- [x] fix rendering of empty data (ex. switching from default Coronaviridae -> Adomaviridae). currently it doesn't update at all
- ~optimize rendering where possible~