### PR TITLE
Update terminology for SRA associations

### DIFF
--- a/src/SDK/DataSdk.jsx
+++ b/src/SDK/DataSdk.jsx
@@ -11,14 +11,14 @@ export default class DataSdk {
         return response.data
     }
 
-    async fetchSraHitsByAccession(genbankAccession, pageNumber, itemsPerPage, identityRange, coverageRange) {
+    async fetchSraMatchesByAccession(genbankAccession, pageNumber, itemsPerPage, identityRange, coverageRange) {
         var identity = constructRangeStr(...identityRange);
         var coverage = constructRangeStr(...coverageRange);
         const response = await axios.get(`${this.baseUrl}/api/genbank/get-runs/${genbankAccession}?page=${pageNumber}&itemsPerPage=${itemsPerPage}&pctId=${identity}&cvgPct=${coverage}`);
         return response.data;
     }
 
-    async fetchSraHitsByFamily(familyName, pageNumber, itemsPerPage, identityRange, coverageRange) {
+    async fetchSraMatchesByFamily(familyName, pageNumber, itemsPerPage, identityRange, coverageRange) {
         var identity = constructRangeStr(...identityRange);
         var coverage = constructRangeStr(...coverageRange);
         const response = await axios.get(`${this.baseUrl}/api/family/get-runs/${familyName}?page=${pageNumber}&itemsPerPage=${itemsPerPage}&pctId=${identity}&score=${coverage}`);

--- a/src/SDK/drawQueryResults.js
+++ b/src/SDK/drawQueryResults.js
@@ -54,16 +54,16 @@ export function drawQueryResults(d3, selector, results, columns) {
         return out;
     }
 
-    function getCoverageData(hit) {
-        var hitCoverageData = [];
-        [...hit.cvg].forEach(function(bit, i) {
-            hitCoverageData.push({
-                sra: hit.sra,
+    function getCoverageData(match) {
+        var matchCoverageData = [];
+        [...match.cvg].forEach(function(bit, i) {
+            matchCoverageData.push({
+                sra: match.sra,
                 bin: i,
                 cartoonChar: bit
             })
         });
-        return hitCoverageData;
+        return matchCoverageData;
     }
 
     // adapted from https://bl.ocks.org/starcalibre/6cccfa843ed254aa0a0d
@@ -119,7 +119,7 @@ export function drawQueryResults(d3, selector, results, columns) {
     function addHeaders(gElement) {
         var yShift = 15;
 
-        var colText = "Hit";
+        var colText = "Match";
         var xShift = sectionMargin.left + rowLabelShiftX;
         var textG = gElement.append("g")
         var text = textG.append("text")
@@ -303,10 +303,10 @@ export function drawQueryResults(d3, selector, results, columns) {
     var chartSvg = d3.select(selector)
         .append("svg")
         .attr("viewBox", `0 0 750 500`);
-    var hitSvg = chartSvg.append("svg")
+    var matchSvg = chartSvg.append("svg")
         .attr("y", tableShiftY);
 
-    drawLegend(hitSvg);
+    drawLegend(matchSvg);
 
     var columnTooltipSvgText = chartSvg.append("text").attr("id", "tooltip");
     var columnHeadersG = chartSvg.append("g")
@@ -314,12 +314,12 @@ export function drawQueryResults(d3, selector, results, columns) {
     addHeaders(columnHeadersG);
     addColumns(columnHeadersG);
 
-    results.forEach((hit, i) => {
-        var coverageData = getCoverageData(hit);
-        var hitG = hitSvg.append("g")
+    results.forEach((match, i) => {
+        var coverageData = getCoverageData(match);
+        var matchG = matchSvg.append("g")
             .attr("class", "sra")
-            .attr("rowid", `${hit.sra}`);
-        var hitSubGroup = drawExpandableRow(hitG, hit.sra, "hit", coverageData, i);
-        addColumns(hitG.select("svg"), hit);
+            .attr("rowid", `${match.sra}`);
+        var matchSubGroup = drawExpandableRow(matchG, match.sra, "match", coverageData, i);
+        addColumns(matchG.select("svg"), match);
     });
 }

--- a/src/components/ExploreChart.jsx
+++ b/src/components/ExploreChart.jsx
@@ -16,7 +16,7 @@ const yColumn = "n";
 const zColumn = "score";
 const zColorLims = ["#3d5088", "#fce540"];
 const xLabel = "% Identity";
-const zLabel = "Hit count";
+const zLabel = "Matches";
 
 // initial value determined by renderChart, then updated by functions
 var xLims;

--- a/src/components/QueryIntro.jsx
+++ b/src/components/QueryIntro.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 const QueryIntro = () => {
     return (
         <div className="text-center">
-            Explore Serratus SRA run hits for a family name or GenBank accession.<br />
+            Explore Serratus SRA run matches for a family name or GenBank accession.<br />
             Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a><br />
             GenBank: <a className="text-blue-600" href="?genbank=EU769558.1">EU769558.1</a><br />
             <br />
-            Alternatively, find Serratus analysis results of a given SRA run accession.<br />
+            Alternatively, find matches associated with a SRA run accession.<br />
             <br />
             Example 1: Frank the Bat (<a className="text-blue-600" href="?run=ERR2756788">ERR2756788</a>)<br />
             Example 2: Ginger the Cat (<a className="text-blue-600" href="?run=SRR7287110">SRR7287110</a>)

--- a/src/helpers/QueryPageHelpers.jsx
+++ b/src/helpers/QueryPageHelpers.jsx
@@ -125,9 +125,9 @@ export const getTitle = async (type, value, valueCorrected) => {
 export const getDataPromise = (type, value, page, itemsPerPage, identityRange, coverageRange) => {
     switch (type) {
         case "family":
-            return dataSdk.fetchSraHitsByFamily(value, page, itemsPerPage, identityRange, coverageRange);
+            return dataSdk.fetchSraMatchesByFamily(value, page, itemsPerPage, identityRange, coverageRange);
         case "genbank":
-            return dataSdk.fetchSraHitsByAccession(value, page, itemsPerPage, identityRange, coverageRange);
+            return dataSdk.fetchSraMatchesByAccession(value, page, itemsPerPage, identityRange, coverageRange);
         case "run":
             return dataSdk.fetchSraRun(value, page);
         default:

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -73,7 +73,7 @@ export default () => {
             <div className={`flex flex-col p-4 w-full ${switchSize}:w-1/3 ${classesBoxBorder}`}>
                 <div className="flex-grow">
                     <div className="pb-2 text-center">
-                        Select a viral family to view the distribution of Serratus analysis results.
+                        Select a viral family to view the distribution of Serratus matches.
                     </div>
                     <Select options={selectOptions}
                         values={selectValues}


### PR DESCRIPTION
Associations between SRA runs and GenBank accessions/families are described as "matches" in the paper. Updating all references in codebase to reflect that.

Visual changes:

1. Explore page: Y axis label, text above dropdown
    - old: https://dev.serratus.io/explore
    - new: https://dev-fix-terminology.serratus.io/explore
2. Query intro text
    - old: https://dev.serratus.io/query
    - new: https://dev-fix-terminology.serratus.io/query
3. Query Column text
    - old1: https://dev.serratus.io/query?family=Coronaviridae
    - new1: https://dev-fix-terminology.serratus.io/query?family=Coronaviridae
    - old2: https://dev.serratus.io/query?genbank=EU769558.1
    - new2: https://dev-fix-terminology.serratus.io/query?genbank=EU769558.1