### PR TITLE
Add bigger limit to Jbrowse BAM loads

### DIFF
--- a/src/pages/Jbrowse.jsx
+++ b/src/pages/Jbrowse.jsx
@@ -22,6 +22,7 @@ const App = (props) => {
 				storeClass : "JBrowse/Store/SeqFeature/BAM",
 				label : bam,
 				type : "JBrowse/View/Track/Alignments2",
+				chunkSizeLimit: 40000000
 			}
 		],
 		includes: null,


### PR DESCRIPTION
- change chunkSizeLimit to 40000000

- Response to this bug found: 

![image](https://user-images.githubusercontent.com/57124913/92284346-c4771180-eecf-11ea-8359-53be3cff4b18.png)

- Live Preview: https://fix-lohrd-jbrowse-data-limit.d1w6d75be7tofa.amplifyapp.com/query?run=SRR6197347&identity=%5B75-100%5D&coverage=%5B0-100%5D

- Click on Parvoviridae and expand the top Accession 'NC_012042.1' to click and view corrected alignment
