### PR TITLE
Add button to download all matches

### DIFF
--- a/src/components/Explorer/Result/ResultHelpers.jsx
+++ b/src/components/Explorer/Result/ResultHelpers.jsx
@@ -11,8 +11,7 @@ import {
     tryGetSraStudyName,
 } from './EntrezApiCalls';
 import {
-    fetchPagedMatchesByGenbank,
-    fetchPagedMatchesByFamily,
+    fetchPagedMatches,
     fetchSraRun,
 } from './SerratusApiCalls';
 
@@ -111,9 +110,9 @@ export const getTitle = async (type, value, valueCorrected) => {
 export const getDataPromise = (type, value, page, perPage, identityRange, coverageRange) => {
     switch (type) {
         case "family":
-            return fetchPagedMatchesByFamily(value, page, perPage, identityRange, coverageRange);
+            return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
         case "genbank":
-            return fetchPagedMatchesByGenbank(value, page, perPage, identityRange, coverageRange);
+            return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
         case "run":
             return fetchSraRun(value);
         default:

--- a/src/components/Explorer/Result/ResultHelpers.jsx
+++ b/src/components/Explorer/Result/ResultHelpers.jsx
@@ -11,6 +11,7 @@ import {
     tryGetSraStudyName,
 } from './EntrezApiCalls';
 import {
+    getMatchesExportUrl,
     fetchPagedMatches,
     fetchSraRun,
 } from './SerratusApiCalls';
@@ -112,4 +113,18 @@ export const getDataPromise = (type, value, page, perPage, identityRange, covera
         return fetchSraRun(value);
     }
     return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
+}
+
+export const ExportButton = (props) => {
+    const {queryType, queryValue, identityLims, coverageLims} = props;
+    const downloadUrl = getMatchesExportUrl(queryType, queryValue, identityLims, coverageLims);
+    return (
+        <div className="flex justify-center">
+            <LinkButton
+                link={downloadUrl}
+                text="Download Matches"
+                icon={downloadIcon}
+                download={true} />
+        </div>
+    )
 }

--- a/src/components/Explorer/Result/ResultHelpers.jsx
+++ b/src/components/Explorer/Result/ResultHelpers.jsx
@@ -11,7 +11,7 @@ import {
     tryGetSraStudyName,
 } from './EntrezApiCalls';
 import {
-    getMatchesExportUrl,
+    getMatchesDownloadUrl,
     fetchPagedMatches,
     fetchSraRun,
 } from './SerratusApiCalls';
@@ -115,9 +115,9 @@ export const getDataPromise = (type, value, page, perPage, identityRange, covera
     return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
 }
 
-export const ExportButton = (props) => {
+export const DownloadButton = (props) => {
     const {queryType, queryValue, identityLims, coverageLims} = props;
-    const downloadUrl = getMatchesExportUrl(queryType, queryValue, identityLims, coverageLims);
+    const downloadUrl = getMatchesDownloadUrl(queryType, queryValue, identityLims, coverageLims);
     return (
         <div className="flex justify-center">
             <LinkButton

--- a/src/components/Explorer/Result/ResultHelpers.jsx
+++ b/src/components/Explorer/Result/ResultHelpers.jsx
@@ -108,13 +108,8 @@ export const getTitle = async (type, value, valueCorrected) => {
 }
 
 export const getDataPromise = (type, value, page, perPage, identityRange, coverageRange) => {
-    switch (type) {
-        case "family":
-            return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
-        case "genbank":
-            return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
-        case "run":
-            return fetchSraRun(value);
-        default:
+    if (type === "run") {
+        return fetchSraRun(value);
     }
+    return fetchPagedMatches(type, value, page, perPage, identityRange, coverageRange);
 }

--- a/src/components/Explorer/Result/SerratusApiCalls.jsx
+++ b/src/components/Explorer/Result/SerratusApiCalls.jsx
@@ -7,7 +7,7 @@ export const fetchSraRun = async (runId) => {
     return response.data;
 }
 
-export const getMatchesExportUrl = (type, value, identityLims, coverageLims) => {
+export const getMatchesDownloadUrl = (type, value, identityLims, coverageLims) => {
     var [identityMin, identityMax] = identityLims;
     var [scoreMin, scoreMax] = coverageLims;
     var params = {

--- a/src/components/Explorer/Result/SerratusApiCalls.jsx
+++ b/src/components/Explorer/Result/SerratusApiCalls.jsx
@@ -7,6 +7,20 @@ export const fetchSraRun = async (runId) => {
     return response.data;
 }
 
+export const getMatchesExportUrl = (type, value, identityLims, coverageLims) => {
+    var [identityMin, identityMax] = identityLims;
+    var [scoreMin, scoreMax] = coverageLims;
+    var params = {
+        scoreMin: scoreMin,
+        scoreMax: scoreMax,
+        identityMin: identityMin,
+        identityMax: identityMax
+    };
+    params[type] = value;
+    const urlParams = new URLSearchParams(params);
+    return `${baseUrl}/matches/nucleotide?${urlParams}`;
+}
+
 export const fetchPagedMatches = async (type, value, page, perPage, identityRange, scoreRange) => {
     var [identityMin, identityMax] = identityRange;
     var [scoreMin, scoreMax] = scoreRange;
@@ -18,7 +32,7 @@ export const fetchPagedMatches = async (type, value, page, perPage, identityRang
         identityMin: identityMin,
         identityMax: identityMax
     };
-    params[type] = value
+    params[type] = value;
     const response = await axios.get(`${baseUrl}/matches/nucleotide/paged`, {params: params});
     return response.data;
 }

--- a/src/components/Explorer/Result/SerratusApiCalls.jsx
+++ b/src/components/Explorer/Result/SerratusApiCalls.jsx
@@ -7,34 +7,18 @@ export const fetchSraRun = async (runId) => {
     return response.data;
 }
 
-export const fetchPagedMatchesByGenbank = async (genbankId, page, perPage, identityRange, scoreRange) => {
+export const fetchPagedMatches = async (type, value, page, perPage, identityRange, scoreRange) => {
     var [identityMin, identityMax] = identityRange;
     var [scoreMin, scoreMax] = scoreRange;
     var params = {
-        genbank: genbankId,
         page: page,
         perPage: perPage,
         scoreMin: scoreMin,
         scoreMax: scoreMax,
         identityMin: identityMin,
         identityMax: identityMax
-    }
-    const response = await axios.get(`${baseUrl}/matches/nucleotide/paged`, {params: params});
-    return response.data;
-}
-
-export const fetchPagedMatchesByFamily = async (familyName, page, perPage, identityRange, scoreRange) => {
-    var [identityMin, identityMax] = identityRange;
-    var [scoreMin, scoreMax] = scoreRange;
-    var params = {
-        family: familyName,
-        page: page,
-        perPage: perPage,
-        scoreMin: scoreMin,
-        scoreMax: scoreMax,
-        identityMin: identityMin,
-        identityMax: identityMax
-    }
+    };
+    params[type] = value
     const response = await axios.get(`${baseUrl}/matches/nucleotide/paged`, {params: params});
     return response.data;
 }

--- a/src/components/Explorer/Result/index.jsx
+++ b/src/components/Explorer/Result/index.jsx
@@ -5,6 +5,7 @@ import {
     getDataPromise,
     getPageLinks,
     getTitle,
+    ExportButton,
 } from './ResultHelpers';
 
 export default (props) => {
@@ -69,6 +70,14 @@ export default (props) => {
                     type={queryType}
                     value={queryValue}
                     dataPromise={dataPromise} />
+                {queryType !== 'run' &&
+                    <ExportButton
+                        queryType={queryType}
+                        queryValue={queryValue}
+                        identityLims={identityLims}
+                        coverageLims={coverageLims}
+                    />
+                }
             </div>
         </div>
     )

--- a/src/components/Explorer/Result/index.jsx
+++ b/src/components/Explorer/Result/index.jsx
@@ -5,7 +5,7 @@ import {
     getDataPromise,
     getPageLinks,
     getTitle,
-    ExportButton,
+    DownloadButton,
 } from './ResultHelpers';
 
 export default (props) => {
@@ -71,7 +71,7 @@ export default (props) => {
                     value={queryValue}
                     dataPromise={dataPromise} />
                 {queryType !== 'run' &&
-                    <ExportButton
+                    <DownloadButton
                         queryType={queryType}
                         queryValue={queryValue}
                         identityLims={identityLims}


### PR DESCRIPTION
This pull request addresses issue #99.

Live preview: https://dev-download-matches.serratus.io/explorer?genbank=NC_034446.1

**Summary of changes**

- consolidate family/genbank API calls
- add button to download all matches, positioned below search results