### PR TITLE
Update navbar links: add Map, remove external GitHub

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -12,11 +12,11 @@ const Navbar = () => {
         <NavLink exact to="/" className="ml-10 w-20 h-8 "><img src="/logo.png" alt="logo"></img></NavLink>
         <div className="justify-flex-end mt-1 mr-10">
           <NavLink exact to="/explorer" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer</NavLink>
+          <NavLink exact to="/geo" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Map (beta)</NavLink>
           <NavLink exact to="/about" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">About</NavLink>
           <NavLink exact to="/team" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Team</NavLink>
           <ExternalLink href="https://www.biorxiv.org/content/10.1101/2020.08.07.241729v1" className="ml-6 bg-white font-mono font-normal border-2 border-gray-600 rounded-lg p-2 hover:text-blue-600 hover:border-blue-600">Preprint</ExternalLink>
           <ExternalLink href="https://github.com/ababaian/serratus/wiki" className="ml-6 bg-white font-mono font-normal border-2 border-gray-600 rounded-lg p-2 hover:text-blue-600 hover:border-blue-600">Wiki</ExternalLink>
-          <ExternalLink href="https://github.com/ababaian/serratus" className="ml-6 bg-white font-mono font-normal border-2 border-gray-600 rounded-lg p-2 hover:text-blue-600 hover:border-blue-600">GitHub</ExternalLink>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Live preview: https://dev-navbar.serratus.io

**Summary of changes**

- Add **Map (beta)** -> /geo
- Remove **GitHub** -> github.com/ababaiain/serratus
    - not a fan of too many external links in navbar, plus **Wiki** already points to the repo.
