### PR TITLE
Click to select Feature of Map -- Development

### DIFF
--- a/src/components/Geo/MapPlot.jsx
+++ b/src/components/Geo/MapPlot.jsx
@@ -37,9 +37,10 @@ export default function MapPlot({ setSelectedPoints }) {
 }
 
 const layout = {
-    mapbox: { style: "open-street-map", zoom: 1 },
+    mapbox: { style: "open-street-map", zoom: 1, pitch: 15 },
     margin: { t: 0, b: 0, l: 0, r: 0 },
     autosize: true,
+    clickmode: 'select',
 };
 
 async function getData() {
@@ -69,10 +70,12 @@ async function getData() {
         type: "scattermapbox",
         lon: unpack(rows, 'coordinate_x'),
         lat: unpack(rows, 'coordinate_y'),
+        mode: "markers",
         customdata: rows,
         text: getHoverText(rows),
         hoverinfo: "text",
-        marker: { color: "Maroon", size: 4 },
-        radius: 3,
+        marker: { color: "Maroon", size: 5, opacity: 1 },
+        radius: 4,
+        selected: {marker: { color: "Purple", size: 7, opacity: 1 } },
     }];
 }

--- a/src/components/Geo/MapPlot.jsx
+++ b/src/components/Geo/MapPlot.jsx
@@ -40,7 +40,7 @@ const layout = {
     mapbox: { style: "open-street-map", zoom: 1, pitch: 15 },
     margin: { t: 0, b: 0, l: 0, r: 0 },
     autosize: true,
-    clickmode: 'select',
+    clickmode: 'select+event',
 };
 
 async function getData() {

--- a/src/components/Geo/index.jsx
+++ b/src/components/Geo/index.jsx
@@ -39,7 +39,7 @@ const Geo = () => {
             <MapPlot setSelectedPoints={setSelectedPoints} />
         </div>
 
-        <div class="text-left text-gray-600">Use <b>`Shift`</b>-click to select multiple points or the <b>`Box Select`</b> or <b>`Lasso Select`</b> icons in the top-right to retrieve a list of sample details.</div>
+        <div class="text-left text-gray-600">Use <b>`Shift`</b>-click to select multiple points or the <b>`Box Select`</b> or <b>`Lasso Select`</b> icons in the top-right.</div>
 
         <SelectionInfo selectedPoints={selectedPoints} />
     </div>

--- a/src/components/Geo/index.jsx
+++ b/src/components/Geo/index.jsx
@@ -32,14 +32,14 @@ const Geo = () => {
             
             <p>This map shows the location of BioSamples from which an intact RdRP sequence could be recovered and geographical meta-data was present.</p>
             
-            <p> A 100-meter randomization is applied to all points to prevent overplotting.</p>
+            <p>A 100-meter randomization is applied to all points to prevent overplotting.</p>
         </div>
 
         <div className="my-2">
             <MapPlot setSelectedPoints={setSelectedPoints} />
         </div>
 
-        <div class="text-left text-gray-600">Use the <b>`Box Select`</b> or <b>`Lasso Select`</b> icons in the top-right to retrieve a list of sample details below the map.</div>
+        <div class="text-left text-gray-600">Use <b>`Shift`</b>-click to select multiple points or the <b>`Box Select`</b> or <b>`Lasso Select`</b> icons in the top-right to retrieve a list of sample details.</div>
 
         <SelectionInfo selectedPoints={selectedPoints} />
     </div>


### PR DESCRIPTION
Current behaviour is that clicking has no effect on the map and double-click resets the map to a full world view.
see: www.serratus.io/geo

-----------------

In `plotly` there is a `layout` setting for all graphs and one of the settings is (`clickmode`](https://plotly.com/python/reference/layout/#layout-clickmode). This defaults to `event` setting but I guess we have no event triggers to make use of this.

I've chnaged `clickmode` to `select` which allows me to set a given point as selected (the same as when box-select is used on multiple points). To confirm this I've changed the color of selected points to "purple" (feature we should include).

The problem currently is that click-select is not loading the table-results of `SelectionInfo` (table below the graph). I can't figure out how the behaviour for loading the table is being triggered to reset and then attach it to `clickmode`.

Current build: https://map-select.d1w6d75be7tofa.amplifyapp.com/