### PR TITLE
RdRP/NT Intro Documentation

### DIFF
--- a/src/components/Explorer/Base/QueryBuilder/CountChart.jsx
+++ b/src/components/Explorer/Base/QueryBuilder/CountChart.jsx
@@ -212,7 +212,7 @@ const getXTicks = () => {
         return xLimValues;
     }
     return xLimValues.filter((d, i) => {
-        if ((xLimValues[0] + i) % 2 === 0) {
+        if ((xLimValues[0] + i) % 5 === 0) {
             return true;
         }
         return false;

--- a/src/components/Explorer/Base/Result/MatchingRuns/Result.jsx
+++ b/src/components/Explorer/Base/Result/MatchingRuns/Result.jsx
@@ -51,6 +51,12 @@ const MatchingRunsResult = ({searchLevel, searchLevelValue, identityLims, scoreL
                     <LinkButtons
                         searchLevel={searchLevel}
                         searchLevelValue={searchLevelValueCorrected} />
+                    <DownloadButton
+                    searchLevel={searchLevel}
+                    searchLevelValue={searchLevelValue}
+                    identityLims={identityLims}
+                    scoreLims={scoreLims}
+                />
                 </div>
             </div>
             <div className="p-6">
@@ -61,12 +67,7 @@ const MatchingRunsResult = ({searchLevel, searchLevelValue, identityLims, scoreL
                     dataPromise={dataPromise} />
                 <ChartController
                     dataPromise={dataPromise} />
-                <DownloadButton
-                    searchLevel={searchLevel}
-                    searchLevelValue={searchLevelValue}
-                    identityLims={identityLims}
-                    scoreLims={scoreLims}
-                />
+
             </div>
         </div>
     )

--- a/src/components/Explorer/Nucleotide/Intro.jsx
+++ b/src/components/Explorer/Nucleotide/Intro.jsx
@@ -7,8 +7,8 @@ const Intro = () => {
     const [showMascot, setShowMascot] = React.useState(false);
 
     return <>
-        <div className="text-3xl text-center">
-            Vertebrate Viral Pangenome (NT)
+        <div className="text-3xl text-center text-maroon">
+            Vertebrate Viral Pangenome (NT) Search
         </div>
 
         <div id="info" class="text-left" >
@@ -57,13 +57,14 @@ const info = <>
         <ExternalLink href="https://s3.amazonaws.com/lovelywater/seq/cov3ma/cov3ma.fa" className="text-blue-600"> (cov3ma.fa) </ExternalLink>
     </div>
     <div>
-    Short reads were aligned against a nucleotide pangenome of:
+    Short reads were aligned against a nucleotide pangenome.
     <ol className="list-decimal list-inside">
         <li>GenBank Coronaviridae sequences clustered at 99% identity (n=10,101)</li>
         <li>non-retrovirus Vertebrate RefSeq Viruses (n=2,849)</li>
         <li><ExternalLink href="https://card.mcmaster.ca/" className="text-blue-600">CARD</ExternalLink> Antimicrobial Resistance (AMR) genes clustered at 95%</li>
     </ol>
     </div>
+    <div> Operational sensitivity: 85-99% genome-wide nucleotide identity. </div>
     <div className="font-bold my-2">
         SRA Search
         <ExternalLink href="https://github.com/ababaian/serratus/wiki/SRA-queries" className="text-blue-600"> (wiki v201210) </ExternalLink>

--- a/src/components/Explorer/Nucleotide/Intro.jsx
+++ b/src/components/Explorer/Nucleotide/Intro.jsx
@@ -13,7 +13,7 @@ const Intro = () => {
 
         <div id="info" class="text-left" >
             <button className="text-xl m-auto" onClick={() => setShowInfo(!showInfo)}>
-                ► Search Information
+                {showInfo ? "▼" : "►"} Search Information
             </button>
             <div className={showInfo ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{info}</div>
@@ -22,7 +22,7 @@ const Intro = () => {
 
         <div id="examples" class="text-left" >
             <button className="text-xl m-auto" onClick={() => setShowExamples(!showExamples)}>
-                ► Examples
+                {showExamples ? "▼" : "►"} Examples
             </button>
             <div className={showExamples ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{examples}</div>
@@ -84,10 +84,7 @@ const examples = <>
     GenBank: <a className="text-blue-600" href="?sequence=NC_045512.2">SARS-CoV-2 (NC_045512.2)</a>, <a className="text-blue-600" href="?sequence=NC_001498.1">Ateline alphaherpesvirus 1 (NC_034446.1)</a>, <a className="text-blue-600" href="?sequence=NC_034446.1">Measles virus (NC_001498.1)</a>...<br />
 
     <br />
-    SRA Run ID:<br />
-    <br />
-    Example 1: Frank the Bat (<a className="text-blue-600" href="?run=ERR2756788">ERR2756788</a>)<br />
-    Example 2: Ginger the Cat (<a className="text-blue-600" href="?run=SRR7287110">SRR7287110</a>)<br />
+    SRA Run ID: <a className="text-blue-600" href="?run=ERR2756788">Frank the Bat (ERR2756788)</a> and  <a className="text-blue-600" href="?run=SRR7287110">Ginger the Cat (SRR7287110)</a><br />
 </>
 
 const mascot = <>

--- a/src/components/Explorer/Nucleotide/Intro.jsx
+++ b/src/components/Explorer/Nucleotide/Intro.jsx
@@ -79,8 +79,7 @@ const examples = <>
     Explore Serratus by virus family name, GenBank accession (in sequence reference), or SRA run identifier.<br />
     <br />
     Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Circoviridae">Circoviridae</a>,  <a className="text-blue-600" href="?family=Reoviridae">Reoviridae</a>... <br />
-
-   
+    <br />
     GenBank: <a className="text-blue-600" href="?sequence=NC_045512.2">SARS-CoV-2 (NC_045512.2)</a>, <a className="text-blue-600" href="?sequence=NC_001498.1">Ateline alphaherpesvirus 1 (NC_034446.1)</a>, <a className="text-blue-600" href="?sequence=NC_034446.1">Measles virus (NC_001498.1)</a>...<br />
 
     <br />

--- a/src/components/Explorer/Nucleotide/Intro.jsx
+++ b/src/components/Explorer/Nucleotide/Intro.jsx
@@ -4,39 +4,60 @@ import { ExternalLink } from 'common';
 const Intro = () => {
     const [showInfo, setShowInfo] = React.useState(false);
     const [showExamples, setShowExamples] = React.useState(true);
+    const [showMascot, setShowMascot] = React.useState(false);
 
     return <>
         <div className="text-3xl text-center">
-            Explorer - Nucleotide Vertebrate RefSeq
+            Vertebrate Viral Pangenome (NT)
         </div>
-        <img className="m-auto h-64" src="/nt_search.png" alt="Nucleotide Search overview" />
-        <div id="info">
-            <button className="text-xl block m-auto" onClick={() => setShowInfo(!showInfo)}>
-                Search Info
+
+        <div id="info" class="text-left" >
+            <button className="text-xl m-auto" onClick={() => setShowInfo(!showInfo)}>
+                ► Search Information
             </button>
             <div className={showInfo ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{info}</div>
             </div>
         </div>
-        <div id="examples">
-            <button className="text-xl block m-auto" onClick={() => setShowExamples(!showExamples)}>
-                Examples
+
+        <div id="examples" class="text-left" >
+            <button className="text-xl m-auto" onClick={() => setShowExamples(!showExamples)}>
+                ► Examples
             </button>
             <div className={showExamples ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{examples}</div>
             </div>
         </div>
+
+        <div id="mascot" class="text-center" >
+            <button className="text-center m-auto" onClick={() => setShowMascot(!showMascot)}>
+                <div align="center" id="Frank">
+                    <img align="center" className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
+                    <i>Serratus mascots: Frank and Ginger</i>
+                </div>
+            </button>
+            <div className={showMascot ? "block" : "hidden"}>
+                <div className="my-2 sm:ml-12">{mascot}</div>
+            </div>
+        </div>
+
+
     </>
 }
 
 export default Intro;
 
 const info = <>
+
+    <img className="m-auto h-64" src="/nt_search.png" alt="Nucleotide Search overview" />
+
     <div className="font-bold mb-2">
-        Sequence Reference: <ExternalLink href="https://github.com/ababaian/serratus/wiki/ref_cov3ma" className="text-blue-600">cov3ma</ExternalLink>
+        Sequence Reference: <i>cov3ma</i>
+        <ExternalLink href="https://github.com/ababaian/serratus/wiki/ref_cov3ma" className="text-blue-600"> (wiki) </ExternalLink>
+        <ExternalLink href="https://s3.amazonaws.com/lovelywater/seq/cov3ma/cov3ma.fa" className="text-blue-600"> (cov3ma.fa) </ExternalLink>
     </div>
     <div>
-    A nucleotide pangenome of:
+    Short reads were aligned against a nucleotide pangenome of:
     <ol className="list-decimal list-inside">
         <li>GenBank Coronaviridae sequences clustered at 99% identity (n=10,101)</li>
         <li>non-retrovirus Vertebrate RefSeq Viruses (n=2,849)</li>
@@ -45,6 +66,7 @@ const info = <>
     </div>
     <div className="font-bold my-2">
         SRA Search
+        <ExternalLink href="https://github.com/ababaian/serratus/wiki/SRA-queries" className="text-blue-600"> (wiki v201210) </ExternalLink>
     </div>
     <ul className="list-disc list-inside">
         <li>3,837,755 libraries (May 2020)</li>
@@ -53,15 +75,22 @@ const info = <>
 </>;
 
 const examples = <>
-    Explore Serratus SRA run matches for a family name or GenBank accession.<br />
+    Explore Serratus by virus family name, GenBank accession (in sequence reference), or SRA run identifier.<br />
     <br />
-    Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a><br />
-    GenBank: <a className="text-blue-600" href="?sequence=NC_034446.1">NC_034446.1</a><br />
+    Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Circoviridae">Circoviridae</a>,  <a className="text-blue-600" href="?family=Reoviridae">Reoviridae</a>... <br />
+
+   
+    GenBank: <a className="text-blue-600" href="?sequence=NC_045512.2">SARS-CoV-2 (NC_045512.2)</a>, <a className="text-blue-600" href="?sequence=NC_001498.1">Ateline alphaherpesvirus 1 (NC_034446.1)</a>, <a className="text-blue-600" href="?sequence=NC_034446.1">Measles virus (NC_001498.1)</a>...<br />
+
     <br />
-    Alternatively, find matches associated with a SRA run accession.<br />
+    SRA Run ID:<br />
     <br />
     Example 1: Frank the Bat (<a className="text-blue-600" href="?run=ERR2756788">ERR2756788</a>)<br />
     Example 2: Ginger the Cat (<a className="text-blue-600" href="?run=SRR7287110">SRR7287110</a>)<br />
-    <img className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
-    <i>The Serratus mascots: Frank and Ginger</i>
+</>
+
+const mascot = <>
+    <div className="text-gray-600"> Serratus is made possible through the promise of collective data-sharing. </div>
+    <div  className="text-gray-600"> If you learn from these data, consider your role in releasing data freely and without restriction.</div>
+    <br />
 </>

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -83,7 +83,7 @@ const examples = <>
 </>
 
 const mascot = <>
-    <div> Serratus is made possible through the promise of collective data-sharing. </div>
-    <div> If you learn from these data, consider your role in releasing data freely and without restriction.</div>
+    <div className="text-gray-600"> Serratus is made possible through the promise of collective data-sharing. </div>
+    <div  className="text-gray-600"> If you learn from these data, consider your role in releasing data freely and without restriction.</div>
     <br />
 </>

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -76,7 +76,7 @@ const examples = <>
     <br />
     Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Qinviridae&identity=45-100&score=25-100">Qinviridae</a>, <a className="text-blue-600" href="family=Quenyaviridae">Quenyaviridae</a>...<br />
     <br />
-    GenBank: <a className="text-blue-600" href="?sequence=NC_001653">Hepatitis Delta Virus (NC_001653)</a>, <a className="text-blue-600" href="?explorer-rdrp?sequence=AAF26709&identity=45-100&score=15-100">Rubella (AAF26709)</a>...<br />
+    GenBank: <a className="text-blue-600" href="?sequence=NC_001653">Hepatitis Delta Virus (NC_001653)</a>, <a className="text-blue-600" href="?sequence=AAF26709&identity=45-100&score=15-100">Rubella (AAF26709)</a>...<br />
     
     <br />
     SRA Run ID: <br />

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -4,6 +4,7 @@ import { helpIcon, ExternalLink } from 'common';
 const Intro = () => {
     const [showInfo, setShowInfo] = React.useState(false);
     const [showExamples, setShowExamples] = React.useState(true);
+    const [showMascot, setShowMascot] = React.useState(false);
 
     const [selectedPoints, setSelectedPoints] = React.useState();
     const [isCollapsed, setIsCollapsed] = React.useState(false);
@@ -31,9 +32,16 @@ const Intro = () => {
             </div>
         </div>
 
-        <div align="center" id="Frank">
-            <img align="center" className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
-            <i>The Serratus mascots: Frank and Ginger</i>
+        <div id="mascot" class="text-center" >
+            <button className="text-center m-auto" onClick={() => setShowMascot(!showMascot)}>
+                <div align="center" id="Frank">
+                    <img align="center" className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
+                    <i>The Serratus mascots: Frank and Ginger</i>
+                </div>
+            </button>
+            <div className={showMascot ? "block" : "hidden"}>
+                <div className="my-2 sm:ml-12">{mascot}</div>
+            </div>
         </div>
     </>
 }
@@ -49,7 +57,7 @@ const info = <>
         <ExternalLink href="https://s3.amazonaws.com/lovelywater/seq/rdrp1/rdrp1.fa" className="text-blue-600"> (rdrp1.fa) </ExternalLink>
     </div>
     <div>
-        Short-reads were translated-nucleotide aligned against an amino-acid collection of RNA dependent RNA Polymerase from all RNA viruses (n = 14,941) and deltavirus antigen.
+        Short-reads were translated-nucleotide alignment against an amino-acid collection of RNA dependent RNA Polymerase from all RNA viruses (n = 14,941) and deltavirus antigen.
     </div>
     <div className="font-bold my-2">
         SRA Search
@@ -74,4 +82,10 @@ const examples = <>
     <br />
     Example 1: Frank the Bat (<a className="text-blue-600" href="?run=ERR2756788">ERR2756788</a>)<br />
     Example 2: Ginger the Cat (<a className="text-blue-600" href="?run=SRR7287110">SRR7287110</a>)<br />
+</>
+
+const mascot = <>
+    <div> Serratus is made possible through the promise of collective data-sharing. </div>
+    <div> If you learn from these data, consider your role in releasing data freely and without restriction.</div>
+    <br />
 </>

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { helpIcon, ExternalLink } from 'common';
+import { ExternalLink } from 'common';
 
 const Intro = () => {
     const [showInfo, setShowInfo] = React.useState(false);
@@ -16,7 +16,7 @@ const Intro = () => {
 
         <div id="info" class="text-left" >
             <button className="text-xl m-auto" onClick={() => setShowInfo(!showInfo)}>
-                ► Search Information
+                {showInfo ? "▼" : "►"} Search Information
             </button>
             <div className={showInfo ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{info}</div>
@@ -25,7 +25,7 @@ const Intro = () => {
 
         <div id="examples" class="text-left" >
             <button className="text-xl m-auto" onClick={() => setShowExamples(!showExamples)}>
-                ► Examples
+                {showExamples ? "▼" : "►"} Examples
             </button>
             <div className={showExamples ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{examples}</div>
@@ -79,10 +79,7 @@ const examples = <>
     GenBank: <a className="text-blue-600" href="?sequence=NC_001653">Hepatitis Delta Virus (NC_001653)</a>, <a className="text-blue-600" href="?sequence=AAF26709&identity=45-100&score=15-100">Rubella (AAF26709)</a>...<br />
     
     <br />
-    SRA Run ID: <br />
-    <br />
-    Example 1: Frank the Bat (<a className="text-blue-600" href="?run=ERR2756788">ERR2756788</a>)<br />
-    Example 2: Ginger the Cat (<a className="text-blue-600" href="?run=SRR7287110">SRR7287110</a>)<br />
+    SRA Run ID: <a className="text-blue-600" href="?run=ERR2756788">Frank the Bat (ERR2756788)</a> and  <a className="text-blue-600" href="?run=SRR7287110">Ginger the Cat (SRR7287110)</a><br />
 </>
 
 const mascot = <>

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -74,7 +74,7 @@ const info = <>
 const examples = <>
     Explore Serratus by virus family name, GenBank accession (in sequence reference), or SRA run identifier.<br />
     <br />
-    Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Qinviridae&identity=45-100&score=25-100">Qinviridae</a>, <a className="text-blue-600" href="family=Quenyaviridae">Quenyaviridae</a>...<br />
+    Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Qinviridae&identity=45-100&score=25-100">Qinviridae</a>, <a className="text-blue-600" href="?family=Quenyaviridae">Quenyaviridae</a>...<br />
     <br />
     GenBank: <a className="text-blue-600" href="?sequence=NC_001653">Hepatitis Delta Virus (NC_001653)</a>, <a className="text-blue-600" href="?sequence=AAF26709&identity=45-100&score=15-100">Rubella (AAF26709)</a>...<br />
     

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -57,8 +57,9 @@ const info = <>
         <ExternalLink href="https://s3.amazonaws.com/lovelywater/seq/rdrp1/rdrp1.fa" className="text-blue-600"> (rdrp1.fa) </ExternalLink>
     </div>
     <div>
-        Short-reads were translated-nucleotide alignment against an amino-acid collection of RNA dependent RNA Polymerase from all RNA viruses (n = 14,941) and deltavirus antigen.
+        Short-reads were translated-nucleotide alignment against an amino-acid collection of RNA dependent RNA Polymerase from all RNA viruses (n = 14,941) and deltavirus antigen. 
     </div>
+    <div> Operational sensitivity: 60-95% RdRP amino acid identity. </div>
     <div className="font-bold my-2">
         SRA Search
         <ExternalLink href="https://github.com/ababaian/serratus/wiki/SRA-queries" className="text-blue-600"> (wiki) </ExternalLink>

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -36,7 +36,7 @@ const Intro = () => {
             <button className="text-center m-auto" onClick={() => setShowMascot(!showMascot)}>
                 <div align="center" id="Frank">
                     <img align="center" className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
-                    <i>The Serratus mascots: Frank and Ginger</i>
+                    <i>Serratus mascots: Frank and Ginger</i>
                 </div>
             </button>
             <div className={showMascot ? "block" : "hidden"}>
@@ -71,7 +71,7 @@ const info = <>
 </>;
 
 const examples = <>
-    Explore Serratus by virus family name, GenBank accession (in sequence refernece), or SRA run identifier.<br />
+    Explore Serratus by virus family name, GenBank accession (in sequence reference), or SRA run identifier.<br />
     <br />
     Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Qinviridae&identity=45-100&score=25-100">Qinviridae</a>, <a className="text-blue-600" href="family=Quenyaviridae">Quenyaviridae</a>...<br />
     <br />

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -5,10 +5,7 @@ const Intro = () => {
     const [showInfo, setShowInfo] = React.useState(false);
     const [showExamples, setShowExamples] = React.useState(true);
     const [showMascot, setShowMascot] = React.useState(false);
-
-    const [selectedPoints, setSelectedPoints] = React.useState();
-    const [isCollapsed, setIsCollapsed] = React.useState(false);
-
+    
     return <>
         <div className="text-3xl text-center">
             RNA Dependent RNA Polymerase (RdRP) Search

--- a/src/components/Explorer/Rdrp/Intro.jsx
+++ b/src/components/Explorer/Rdrp/Intro.jsx
@@ -1,30 +1,39 @@
 import React from 'react';
-import { ExternalLink } from 'common';
+import { helpIcon, ExternalLink } from 'common';
 
 const Intro = () => {
     const [showInfo, setShowInfo] = React.useState(false);
     const [showExamples, setShowExamples] = React.useState(true);
 
+    const [selectedPoints, setSelectedPoints] = React.useState();
+    const [isCollapsed, setIsCollapsed] = React.useState(false);
+
     return <>
         <div className="text-3xl text-center">
-            Explorer - RdRP
+            RNA Dependent RNA Polymerase (RdRP) Search
         </div>
-        <img className="m-auto h-64" src="/rdrp_search.png" alt="RdRP Search overview" />
-        <div id="info">
-            <button className="text-xl block m-auto" onClick={() => setShowInfo(!showInfo)}>
-                Search Info
+
+        <div id="info" class="text-left" >
+            <button className="text-xl m-auto" onClick={() => setShowInfo(!showInfo)}>
+                ► Search Information
             </button>
             <div className={showInfo ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{info}</div>
             </div>
         </div>
-        <div id="examples">
-            <button className="text-xl block m-auto" onClick={() => setShowExamples(!showExamples)}>
-                Examples
+
+        <div id="examples" class="text-left" >
+            <button className="text-xl m-auto" onClick={() => setShowExamples(!showExamples)}>
+                ► Examples
             </button>
             <div className={showExamples ? "block" : "hidden"}>
                 <div className="my-2 sm:ml-12">{examples}</div>
             </div>
+        </div>
+
+        <div align="center" id="Frank">
+            <img align="center" className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
+            <i>The Serratus mascots: Frank and Ginger</i>
         </div>
     </>
 }
@@ -32,32 +41,37 @@ const Intro = () => {
 export default Intro;
 
 const info = <>
+    <img className="m-auto h-64" src="/rdrp_search.png" alt="RdRP Search overview" />
+
     <div className="font-bold mb-2">
-        Sequence Reference: <ExternalLink href="https://github.com/ababaian/serratus/wiki/ref_rdrp1" className="text-blue-600">rdrp1</ExternalLink>
+        Sequence Reference: <i>rdrp1</i>
+        <ExternalLink href="https://github.com/ababaian/serratus/wiki/ref_rdrp1" className="text-blue-600"> (wiki) </ExternalLink>
+        <ExternalLink href="https://s3.amazonaws.com/lovelywater/seq/rdrp1/rdrp1.fa" className="text-blue-600"> (rdrp1.fa) </ExternalLink>
     </div>
     <div>
-        An amino-acid collection of all available RNA dependent RNA Polymerase sequences (n = 14,941)
+        Short-reads were translated-nucleotide aligned against an amino-acid collection of RNA dependent RNA Polymerase from all RNA viruses (n = 14,941) and deltavirus antigen.
     </div>
     <div className="font-bold my-2">
         SRA Search
+        <ExternalLink href="https://github.com/ababaian/serratus/wiki/SRA-queries" className="text-blue-600"> (wiki) </ExternalLink>
     </div>
     <ul className="list-disc list-inside">
-        <li>5,686,715 libraries (Jan 2021)</li>
-        <li>Transcriptome, meta-Transcriptome, metagenome, viromes and environmental</li>
-        <li>Mammalian genome and exome</li>
+        <li> 5,686,715 libraries (Jan 2021)</li>
+        <li>All Transcriptome, Metatranscriptome, Metagenome, Virome, and Environmental sequencing</li>
+        <li>Genome and Exome for non-human non-mouse mammals</li>
     </ul>
 </>;
 
 const examples = <>
-    Explore Serratus SRA run matches for a family name or GenBank accession.<br />
+    Explore Serratus by virus family name, GenBank accession (in sequence refernece), or SRA run identifier.<br />
     <br />
-    Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a><br />
-    GenBank: <a className="text-blue-600" href="?sequence=NC_001653">NC_001653</a><br />
+    Family: <a className="text-blue-600" href="?family=Coronaviridae">Coronaviridae</a>, <a className="text-blue-600" href="?family=Qinviridae&identity=45-100&score=25-100">Qinviridae</a>, <a className="text-blue-600" href="family=Quenyaviridae">Quenyaviridae</a>...<br />
     <br />
-    Alternatively, find matches associated with a SRA run accession.<br />
+    GenBank: <a className="text-blue-600" href="?sequence=NC_001653">Hepatitis Delta Virus (NC_001653)</a>, <a className="text-blue-600" href="?explorer-rdrp?sequence=AAF26709&identity=45-100&score=15-100">Rubella (AAF26709)</a>...<br />
+    
+    <br />
+    SRA Run ID: <br />
     <br />
     Example 1: Frank the Bat (<a className="text-blue-600" href="?run=ERR2756788">ERR2756788</a>)<br />
     Example 2: Ginger the Cat (<a className="text-blue-600" href="?run=SRR7287110">SRR7287110</a>)<br />
-    <img className="h-64" src="/Frank_Ginger.png" alt="Frank and Ginger, the Serratus mascots" />
-    <i>The Serratus mascots: Frank and Ginger</i>
 </>

--- a/src/components/Explorer/Rdrp/index.jsx
+++ b/src/components/Explorer/Rdrp/index.jsx
@@ -36,7 +36,7 @@ export default function RdrpExplorer({location}) {
                 },
                 "percent_identity": {
                     "name": "Identity",
-                    "desc": "Alignment identity",
+                    "desc": "Alignment identity (aa)",
                     "size": 70,
                     "valueSuffix": "%",
                     "domain": [45, 100],


### PR DESCRIPTION
Updated the wording and examples for hte RdRP/NT Intro pages.

[Dev Page Link](https://rdrp-doc.d1w6d75be7tofa.amplifyapp.com/)

- Added triangle unicode to section titles to indicate it is click to expand
-  Moved the "search image overview" to within the Search Information tab.
- Moved "Download Matches" button to top of results page
- Added data-share message to click-on-mascots
- Some minor typo and documentation fixes
- Query Chart now uses increments of 5 instead of 2 to prevent overplotting of numbers
