### PR TITLE
Restore /explorer route as primary, remove stale redirects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,17 +32,17 @@ const App = () => {
       <Navbar></Navbar>
       <Switch>
         <Route exact path="/" component={Home} />
-        <Route exact path="/explorer-nt" component={NucleotideExplorer} />
+        <Route exact path="/explorer" component={NucleotideExplorer} />
         <Route exact path="/explorer-rdrp" component={RdrpExplorer} />
         <Route exact path="/about" component={About} />
         <Route exact path="/team" component={Team} />
         <Route exact path="/jbrowse" component={Jbrowse} />
         <Route exact path="/geo" component={Geo} />
         <Route exact path="/access" component={Access} />
-        <Route exact path="/explorer" component={() => {return <Redirect to="/explorer-nt" />}} />
-        <Route exact path="/family" component={() => {return <Redirect to="/explorer-nt" />}} />
-        <Route exact path="/explore" component={() => {return <Redirect to="/explorer-nt" />}} />
-        <Route exact path="/query" component={() => {return <Redirect to="/explorer-nt" />}} />
+        <Route exact path="/family" component={() => {return <Redirect to="/explorer" />}} />
+        <Route exact path="/explore" component={() => {return <Redirect to="/explorer" />}} />
+        <Route exact path="/query" component={() => {return <Redirect to="/explorer" />}} />
+        <Route exact path="/explorer-nt" component={() => {return <Redirect to="/explorer" />}} />
       </Switch>
       {window.location.pathname !== "/" && <Footer />}
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,9 @@ const App = () => {
         <Route exact path="/jbrowse" component={Jbrowse} />
         <Route exact path="/geo" component={Geo} />
         <Route exact path="/access" component={Access} />
+        <Route exact path="/family" component={() => {return <Redirect to="/explorer" />}} />
+        <Route exact path="/explore" component={() => {return <Redirect to="/explorer" />}} />
+        <Route exact path="/query" component={() => {return <Redirect to="/explorer" />}} />
         <Route exact path="/explorer-nt" component={() => {return <Redirect to="/explorer" />}} />
       </Switch>
       {window.location.pathname !== "/" && <Footer />}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,9 +39,6 @@ const App = () => {
         <Route exact path="/jbrowse" component={Jbrowse} />
         <Route exact path="/geo" component={Geo} />
         <Route exact path="/access" component={Access} />
-        <Route exact path="/family" component={() => {return <Redirect to="/explorer" />}} />
-        <Route exact path="/explore" component={() => {return <Redirect to="/explorer" />}} />
-        <Route exact path="/query" component={() => {return <Redirect to="/explorer" />}} />
         <Route exact path="/explorer-nt" component={() => {return <Redirect to="/explorer" />}} />
       </Switch>
       {window.location.pathname !== "/" && <Footer />}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -11,8 +11,8 @@ const Navbar = () => {
       <div className="hidden sm:flex flex-row w-screen bg-gray-100 sm:p-4 justify-between z-10 border-b-2  border-gray-300">
         <NavLink exact to="/" className="ml-10 w-20 h-8 "><img src="/logo.png" alt="logo"></img></NavLink>
         <div className="justify-flex-end mt-1 mr-10">
-          <NavLink exact to="/explorer-nt" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer (NT)</NavLink>
-          <NavLink exact to="/explorer-rdrp" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer (RdRP)</NavLink>
+          <NavLink exact to="/explorer" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer</NavLink>
+          <NavLink exact to="/explorer-rdrp" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">RdRP Explorer (beta)</NavLink>
           <NavLink exact to="/geo" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Map (beta)</NavLink>
           <NavLink exact to="/about" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">About</NavLink>
           <NavLink exact to="/team" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Team</NavLink>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -11,8 +11,8 @@ const Navbar = () => {
       <div className="hidden sm:flex flex-row w-screen bg-gray-100 sm:p-4 justify-between z-10 border-b-2  border-gray-300">
         <NavLink exact to="/" className="ml-10 w-20 h-8 "><img src="/logo.png" alt="logo"></img></NavLink>
         <div className="justify-flex-end mt-1 mr-10">
-          <NavLink exact to="/explorer" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer</NavLink>
-          <NavLink exact to="/explorer-rdrp" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">RdRP Explorer (beta)</NavLink>
+          <NavLink exact to="/explorer" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer (NT)</NavLink>
+          <NavLink exact to="/explorer-rdrp" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Explorer (RdRP)</NavLink>
           <NavLink exact to="/geo" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Map (beta)</NavLink>
           <NavLink exact to="/about" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">About</NavLink>
           <NavLink exact to="/team" className="ml-10 hover:text-blue-800" activeClassName="text-blue-600">Team</NavLink>


### PR DESCRIPTION
We need to retain links like https://serratus.io/explorer?run=ERR2756788.

Live preview: https://dev-routes.serratus.io/explorer?run=ERR2756788