### PR TITLE
Remove react-spring transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15631,15 +15631,6 @@
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
-    "react-spring": {
-      "version": "8.0.27",
-      "resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
-      "integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "react-plotly.js": "^2.5.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
-    "react-select": "^3.1.0",
-    "react-spring": "^8.0.27"
+    "react-select": "^3.1.0"
   },
   "scripts": {
     "build:css": "postcss src/styles/tailwind.css -o src/styles/main.css",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactGA from 'react-ga'
-import { useTransition } from 'react-spring'
-import { Route, useLocation, Switch, Redirect } from 'react-router-dom'
+import { Route, Switch, Redirect } from 'react-router-dom'
 import { Home } from './pages/Home'
 import { Navbar } from './components/Navbar'
 import { NucleotideExplorer } from './components/Explorer/Nucleotide'
@@ -19,13 +18,6 @@ export const App = () => {
         // track initial page load
         ReactGA.pageview(window.location.pathname + window.location.search)
     }, [])
-
-    const location = useLocation()
-    useTransition(location, (location) => location.pathname, {
-        from: { opacity: 0, transform: 'translate(100%, 0)' },
-        enter: { opacity: 1, transform: 'translate(0, 0)' },
-        leave: { opacity: 0, transform: 'translate(-100%, 0)' },
-    })
 
     return (
         <div>


### PR DESCRIPTION
The single transition used by `react-spring` in our app doesn't seem to make any visual difference with or without it.

Live preview: https://dev-refactor.serratus.io