### PR TITLE
Use nested routes for Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serratus-react",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "/",
   "dependencies": {
     "@jbrowse/react-linear-genome-view": "^1.3.2",
     "axios": "^0.21.1",

--- a/src/common/routes.jsx
+++ b/src/common/routes.jsx
@@ -17,11 +17,11 @@ export const routes = {
         exact: true,
     },
     nucleotideExplorer: {
-        path: '/explorer',
+        path: '/explorer/nt',
         component: NucleotideExplorer,
     },
     rdrpExplorer: {
-        path: '/explorer-rdrp',
+        path: '/explorer/rdrp',
         component: RdrpExplorer,
     },
     about: {
@@ -44,20 +44,13 @@ export const routes = {
         path: '/access',
         component: Access,
     },
-    family: {
-        path: '/family',
-        component: () => <Redirect to='/explorer' />,
+    explorer: {
+        path: '/explorer',
+        component: ({ location }) => <Redirect to={{ ...location, pathname: '/explorer/nt' }} />,
+        exact: true,
     },
-    explore: {
-        path: '/explore',
-        component: () => <Redirect to='/explorer' />,
-    },
-    query: {
-        path: '/query',
-        component: () => <Redirect to='/explorer' />,
-    },
-    nucleotideExplorer2: {
-        path: '/explorer-nt',
-        component: () => <Redirect to='/explorer' />,
+    explorerRdrpOld: {
+        path: '/explorer-rdrp',
+        component: ({ location }) => <Redirect to={{ ...location, pathname: '/explorer/rdrp' }} />,
     },
 }

--- a/src/components/Explorer/Base/QueryBuilder/QueryBuilder.jsx
+++ b/src/components/Explorer/Base/QueryBuilder/QueryBuilder.jsx
@@ -79,7 +79,7 @@ export const QueryBuilder = ({
             identity: constructRangeStr(...identityLimsRef.current),
             score: constructRangeStr(...scoreLimsRef.current),
         })
-        const base = window.location.pathname.slice(1)
+        const base = window.location.pathname.split('/').pop()
         const searchUrl = `${base}?${params.toString()}#${resultSectionId}`
         window.location.href = searchUrl
     }


### PR DESCRIPTION
Live preview: https://dev-routes.serratus.io/

After fixing #127, we can now use new routes per https://github.com/serratus-bio/serratus.io/discussions/120#discussioncomment-478736:

- `/explorer` -> `/explorer/nt`
- `/explorer-rdrp` -> `/explorer/rdrp`

Modified `Redirect`s to include URL query parameters so old links like these are re-routed properly:

- https://serratus.io/explorer?run=ERR2756788&identity=45-100&score=50-100
- https://serratus.io/explorer-rdrp?sequence=NC_001653&identity=45-100&score=50-100

Also, removed stale redirects:

- `/query`
- `/family`
- `/explore`
- `/explorer-nt`

ref #112