### PR TITLE
Fix JBrowse link with nested URL path

### DIFF
--- a/src/components/Explorer/Base/Result/MatchChart/IMatchRow.tsx
+++ b/src/components/Explorer/Base/Result/MatchChart/IMatchRow.tsx
@@ -141,7 +141,7 @@ export class IMatchRow {
 
     addJBrowseIcon() {
         const image = '/atcg.png'
-        const link = `jbrowse?bam=${this.data.run_id}&loc=${this.value}`
+        const link = `/jbrowse?bam=${this.data.run_id}&loc=${this.value}`
         const iconWidth = 15
         const iconHeight = 15
         const xShift = 725 // TODO: compute from colMap


### PR DESCRIPTION
Fixes a bug introduced by #143 where JBrowse links go to `/explorer/jbrowse?...`.

Live preview: https://dev-routes.serratus.io/