### PR TITLE
Use debounce function to Improve performance of match count chart

### DIFF
--- a/src/components/Explorer/Base/QueryBuilder/QueryBuilder.jsx
+++ b/src/components/Explorer/Base/QueryBuilder/QueryBuilder.jsx
@@ -13,6 +13,7 @@ import { ExternalLink, helpIcon } from 'common'
 import { SearchLevelSelector } from './SearchLevelSelector'
 import { fetchMatchCounts } from './SerratusApiCalls'
 import { BaseContext } from 'components/Explorer/Base/BaseContext'
+import { debounce } from './debounce'
 
 export const QueryBuilder = ({
     identityLimsRef,
@@ -24,6 +25,7 @@ export const QueryBuilder = ({
 }) => {
     const context = React.useContext(BaseContext)
     const [errorMessage, setErrorMessage] = React.useState('')
+    const debounceTime = 50
 
     // initial chart render
     const chartRendered = React.useRef(false)
@@ -103,8 +105,8 @@ export const QueryBuilder = ({
                             id='sliderIdentity'
                             sliderDomain={context.domain.identity}
                             sliderLimsRef={identityLimsRef}
-                            onChange={updateX}
-                            onTouchEnd={updateY}
+                            onChange={debounce(updateX, debounceTime)}
+                            onTouchEnd={() => setTimeout(updateY, debounceTime)}
                         />
                     </div>
                     <div className='mx-2'>
@@ -114,8 +116,8 @@ export const QueryBuilder = ({
                             sliderDomain={context.domain.score}
                             sliderLimsRef={scoreLimsRef}
                             linearGradientString={context.theme.gradientString}
-                            onChange={updateZ}
-                            onTouchEnd={updateY}
+                            onChange={debounce(updateZ, debounceTime)}
+                            onTouchEnd={() => setTimeout(updateY, debounceTime)}
                         />
                     </div>
                 </div>

--- a/src/components/Explorer/Base/QueryBuilder/debounce.js
+++ b/src/components/Explorer/Base/QueryBuilder/debounce.js
@@ -1,0 +1,16 @@
+// https://davidwalsh.name/javascript-debounce-function
+export function debounce(func, wait, immediate) {
+    let timeout
+    return function () {
+        let context = this,
+            args = arguments
+        let later = function () {
+            timeout = null
+            if (!immediate) func.apply(context, args)
+        }
+        let callNow = immediate && !timeout
+        clearTimeout(timeout)
+        timeout = setTimeout(later, wait)
+        if (callNow) func.apply(context, args)
+    }
+}


### PR DESCRIPTION
Current: https://serratus.io/explorer/rdrp
Preview: https://dev-chart.serratus.io/explorer/rdrp

Currently, the chart contents (one `rect` per identity+score bin) are redrawn by D3 every time the value of a range slider changes. This makes it extremely sluggish on the average machine.

This is a common problem with web events (`onChange`, `onScroll`, etc.) and a good solution is the [debounce function](https://davidwalsh.name/javascript-debounce-function). Downside is a slight delay before actual invocation, but that's much more favorable than the existing lag.