### PR TITLE
Trees: update tip info, new SVGs and user guidance

### DIFF
--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -25,10 +25,9 @@ export const Trees = () => {
         </Helmet>
     )
 
-    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-21/svg_noscale/${selected[searchLevel]}.svg`
-    const msaSvgScaledLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-21/svg_scale/${selected[searchLevel]}.svg`
-    const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees/tree/${selected[searchLevel]}.newick`
-    const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees/msa/${selected[searchLevel]}.fasta`
+    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/svg/${selected[searchLevel]}.svg`
+    const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/newick/${selected[searchLevel]}.newick`
+    const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/msa/${selected[searchLevel]}.fasta`
     const reactMsaViewParams = {
         msaview: {
             data: {},
@@ -96,6 +95,13 @@ export const Trees = () => {
                         download={true}
                     />
                     <LinkButton
+                        link={msaSvgLink}
+                        text='SVG'
+                        icon={downloadIcon}
+                        download={true}
+                        newTab={true}
+                    />
+                    <LinkButton
                         link={reactMsaViewLink}
                         text='MSA Viewer'
                         icon={externalLinkIcon}
@@ -114,16 +120,8 @@ export const Trees = () => {
                                 : 'flex flex-col justify-center items-center w-full'
                         }>
                         <div className='text-center my-2'>
-                            Some of these trees are large. To read tip labels, you may have to the
-                            SVG image file{' '}
-                            <ExternalLink href={msaSvgLink} className='text-blue-600'>
-                                here (constant size)
-                            </ExternalLink>
-                            or{' '}
-                            <ExternalLink href={msaSvgScaledLink} className='text-blue-600'>
-                                here (size scaled to # leaves)
-                            </ExternalLink>
-                            .
+                            Some of these trees are large. To read tip labels, use the buttons above
+                            to open the external MSA Viewer or download the SVG.
                         </div>
                         <img
                             className='w-3/4 lg:w-1/3'

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -25,7 +25,7 @@ export const Trees = () => {
         </Helmet>
     )
 
-    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg/${selected[searchLevel]}.svg`
+    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-20/${selected[searchLevel]}.svg`
     const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees/tree/${selected[searchLevel]}.newick`
     const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees/msa/${selected[searchLevel]}.fasta`
     const reactMsaViewParams = {

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -110,8 +110,16 @@ export const Trees = () => {
                         className={
                             loading
                                 ? 'invisible'
-                                : 'flex flex-row justify-center items-center w-full'
+                                : 'flex flex-col justify-center items-center w-full'
                         }>
+                        <div className='text-center my-2'>
+                            Some of these trees are large. To read tip labels, you may have to the
+                            SVG image file{' '}
+                            <ExternalLink href={msaSvgLink} className='text-blue-600'>
+                                here
+                            </ExternalLink>
+                            .
+                        </div>
                         <img
                             className='w-3/4 lg:w-1/3'
                             src={msaSvgLink}

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -117,22 +117,6 @@ export const Trees = () => {
                             src={msaSvgLink}
                             onLoad={() => setLoading(false)}
                         />
-                        <div className='flex flex-col'>
-                            <div className='flex flex-row'>
-                                <span
-                                    className='w-5 h-5 mr-2'
-                                    style={{ backgroundColor: '#017500' }}
-                                />
-                                GenBank / Known RdRP
-                            </div>
-                            <div className='flex flex-row'>
-                                <span
-                                    className='w-5 h-5 mr-2'
-                                    style={{ backgroundColor: '#ff03ff' }}
-                                />
-                                Serratus RdRP
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -25,7 +25,7 @@ export const Trees = () => {
         </Helmet>
     )
 
-    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-20/${selected[searchLevel]}.svg`
+    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-21/${selected[searchLevel]}.svg`
     const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees/tree/${selected[searchLevel]}.newick`
     const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees/msa/${selected[searchLevel]}.fasta`
     const reactMsaViewParams = {

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -25,7 +25,8 @@ export const Trees = () => {
         </Helmet>
     )
 
-    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-21/${selected[searchLevel]}.svg`
+    const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-21/svg_noscale/${selected[searchLevel]}.svg`
+    const msaSvgScaledLink = `https://s3.amazonaws.com/serratus.io/trees/svg-2021-11-21/svg_scale/${selected[searchLevel]}.svg`
     const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees/tree/${selected[searchLevel]}.newick`
     const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees/msa/${selected[searchLevel]}.fasta`
     const reactMsaViewParams = {
@@ -116,7 +117,11 @@ export const Trees = () => {
                             Some of these trees are large. To read tip labels, you may have to the
                             SVG image file{' '}
                             <ExternalLink href={msaSvgLink} className='text-blue-600'>
-                                here
+                                here (constant size)
+                            </ExternalLink>
+                            or{' '}
+                            <ExternalLink href={msaSvgScaledLink} className='text-blue-600'>
+                                here (size scaled to # leaves)
                             </ExternalLink>
                             .
                         </div>


### PR DESCRIPTION
**Summary of changes**

- Add species labels where available.
- Remove known vs. novel tip coloring. From @rcedgar:
    > decided to drop it because coloring will quickly be obsolete, too much bother to keep this updated
   > the "right" way to do it long term would be to integrate the web site with palmdb
- Direct users to use the MSA viewer or SVG download to read tip labels.