### PR TITLE
Set default score filter range for run level to 0-100

### DIFF
--- a/src/components/Explorer/Base/BaseContext.tsx
+++ b/src/components/Explorer/Base/BaseContext.tsx
@@ -20,9 +20,11 @@ export type BaseContextType = {
         identity: RangeFilter
         score: RangeFilter
     }
-    defaultFilterRanges: {
-        identity: RangeFilter
-        score: RangeFilter
+    defaultFilterRangesBySearchLevel: {
+        [key: string]: {
+            identity: RangeFilter
+            score: RangeFilter
+        }
     }
     result: {
         addJbrowseLinks: boolean

--- a/src/components/Explorer/Base/ExplorerBase.tsx
+++ b/src/components/Explorer/Base/ExplorerBase.tsx
@@ -17,6 +17,12 @@ export const ExplorerBase = ({ location }: { location: Location }) => {
     const [inputSearchLevel, inputSearchLevelValue] = getInputSearchLevel(searchLevels, urlParams)
     const searchLevelProvided = Boolean(inputSearchLevel)
 
+    // values that change with user input (QueryBuilder)
+    // family must be valid for initial chart render
+    const [searchLevel, setSearchLevel] = React.useState(inputSearchLevel || 'family')
+    const [searchLevelValue, setSearchLevelValue] = React.useState(
+        inputSearchLevelValue || 'Coronaviridae'
+    )
     // set filter ranges / defaults
     const inputIdentityLims =
         parseRange(urlParams.get('identity'), context.domain.identity) ||
@@ -24,13 +30,6 @@ export const ExplorerBase = ({ location }: { location: Location }) => {
     const inputScoreLims =
         parseRange(urlParams.get('score'), context.domain.score) ||
         context.defaultFilterRanges.score
-
-    // values that change with user input (QueryBuilder)
-    // family must be valid for initial chart render
-    const [searchLevel, setSearchLevel] = React.useState(inputSearchLevel || 'family')
-    const [searchLevelValue, setSearchLevelValue] = React.useState(
-        inputSearchLevelValue || 'Coronaviridae'
-    )
     const identityLimsRef = React.useRef(inputIdentityLims)
     const scoreLimsRef = React.useRef(inputScoreLims)
 

--- a/src/components/Explorer/Base/ExplorerBase.tsx
+++ b/src/components/Explorer/Base/ExplorerBase.tsx
@@ -26,10 +26,10 @@ export const ExplorerBase = ({ location }: { location: Location }) => {
     // set filter ranges / defaults
     const inputIdentityLims =
         parseRange(urlParams.get('identity'), context.domain.identity) ||
-        context.defaultFilterRanges.identity
+        context.defaultFilterRangesBySearchLevel[searchLevel].identity
     const inputScoreLims =
         parseRange(urlParams.get('score'), context.domain.score) ||
-        context.defaultFilterRanges.score
+        context.defaultFilterRangesBySearchLevel[searchLevel].score
     const identityLimsRef = React.useRef(inputIdentityLims)
     const scoreLimsRef = React.useRef(inputScoreLims)
 

--- a/src/components/Explorer/Nucleotide/NucleotideExplorer.tsx
+++ b/src/components/Explorer/Nucleotide/NucleotideExplorer.tsx
@@ -27,9 +27,19 @@ export const NucleotideExplorer = ({ location }: Props) => {
             identity: [75, 100],
             score: [0, 100],
         },
-        defaultFilterRanges: {
-            identity: [75, 100],
-            score: [50, 100],
+        defaultFilterRangesBySearchLevel: {
+            family: {
+                identity: [75, 100],
+                score: [50, 100],
+            },
+            sequence: {
+                identity: [75, 100],
+                score: [50, 100],
+            },
+            run: {
+                identity: [75, 100],
+                score: [0, 100],
+            },
         },
         result: {
             addJbrowseLinks: true,

--- a/src/components/Explorer/Rdrp/RdrpExplorer.tsx
+++ b/src/components/Explorer/Rdrp/RdrpExplorer.tsx
@@ -27,9 +27,19 @@ export const RdrpExplorer = ({ location }: Props) => {
             identity: [45, 100],
             score: [0, 100],
         },
-        defaultFilterRanges: {
-            identity: [45, 100],
-            score: [50, 100],
+        defaultFilterRangesBySearchLevel: {
+            family: {
+                identity: [45, 100],
+                score: [50, 100],
+            },
+            sequence: {
+                identity: [45, 100],
+                score: [50, 100],
+            },
+            run: {
+                identity: [45, 100],
+                score: [0, 100],
+            },
         },
         result: {
             addJbrowseLinks: false,


### PR DESCRIPTION
Set the default score filter range for the `run` search level to `[0,100]` for both Nucleotide and RdRP Explorer. This only affects URLs that are direct links without any range set in the URL params (e.g. https://dev.serratus.io/explorer/rdrp?run=ERR2756788 will show `[0,100]` which is new behavior, but an explicit link https://dev.serratus.io/explorer/rdrp?run=ERR2756788&identity=45-100&score=50-100 will still show `[50,100]`.

Switching between filter levels in the query builder also has no affect on the filter ranges (the default ranges are only applied on page load).

Closes #161.