### PR TITLE
Add `/community` redirect to Google form

### DIFF
--- a/src/common/routes.jsx
+++ b/src/common/routes.jsx
@@ -69,4 +69,11 @@ export const routes = {
         path: '/explorer-rdrp',
         component: ({ location }) => <Redirect to={{ ...location, pathname: '/explorer/rdrp' }} />,
     },
+    community: {
+        path: '/community',
+        component: () => {
+            window.location.href = 'https://forms.gle/jq5V5TqvAAT7bfuf9'
+            return null
+        },
+    },
 }


### PR DESCRIPTION
This pull request addresses @ababaian's Slack thread: [Create a simple "Join the mailing list" page](https://hackseq-rna.slack.com/archives/C012FU1JF0V/p1646653474043629)

Try: https://community-redirect.serratus.io/community

Another option would be to embed the form in an `<iframe>`, but that can come later and this simple redirect is better than nothing.