### PR TITLE
Use squash merge for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --squash --auto "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.SERRATUS_BOT_TOKEN}}


### PR DESCRIPTION
Fixes error in [this run](https://github.com/serratus-bio/serratus.io/runs/6182669416?check_suite_focus=true):

```
Run gh pr merge --auto --merge "$PR_URL"
Message: ["Merge method merge commits are not allowed on this repository"], Locations: [{Line:1 Column:72}]
Error: Process completed with exit code 1.
```
