### PR TITLE
Adds a tree explorer link-out

### DIFF
--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -29,8 +29,6 @@ export const Trees = () => {
     const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/newick/${selected[searchLevel]}.newick`
     const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/msa/${selected[searchLevel]}.fasta`
 
-    const msaTaxoniumLink = `https://taxonium.org/?treeUrl=${encodeURIComponent(msaNewickLink)}&ladderizeTree=false`
-
     const reactMsaViewParams = {
         msaview: {
             data: {},
@@ -63,7 +61,12 @@ export const Trees = () => {
     const reactMsaViewLink = `https://gmod.github.io/react-msaview/?data=${encodeURIComponent(
         JSON.stringify(reactMsaViewParams)
     )}#`
-    
+
+    const msaTaxoniumConfig = { title: "Serratus: " + selected[searchLevel] }
+    const msaTaxoniumLink = `https://taxonium.org/?treeUrl=${encodeURIComponent(msaNewickLink)}&ladderizeTree=false&config=${encodeURIComponent(
+        JSON.stringify(msaTaxoniumConfig)
+    )}`
+
 
     return (
         <>
@@ -106,14 +109,14 @@ export const Trees = () => {
                         newTab={true}
                     />
                     <LinkButton
-                        link={msaTaxoniumLink}
-                        text='Tree viewer'
+                        link={reactMsaViewLink}
+                        text='MSA Viewer'
                         icon={externalLinkIcon}
                         newTab={true}
                     />
                     <LinkButton
-                        link={reactMsaViewLink}
-                        text='MSA Viewer'
+                        link={msaTaxoniumLink}
+                        text='Tree Viewer'
                         icon={externalLinkIcon}
                         newTab={true}
                     />

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -28,6 +28,9 @@ export const Trees = () => {
     const msaSvgLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/svg/${selected[searchLevel]}.svg`
     const msaNewickLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/newick/${selected[searchLevel]}.newick`
     const msaFastaLink = `https://s3.amazonaws.com/serratus.io/trees-2021-11-27/msa/${selected[searchLevel]}.fasta`
+
+    const msaTaxoniumLink = `https://taxonium.org/?treeUrl=${encodeURIComponent(msaNewickLink)}&ladderizeTree=false`
+
     const reactMsaViewParams = {
         msaview: {
             data: {},
@@ -60,6 +63,7 @@ export const Trees = () => {
     const reactMsaViewLink = `https://gmod.github.io/react-msaview/?data=${encodeURIComponent(
         JSON.stringify(reactMsaViewParams)
     )}#`
+    
 
     return (
         <>
@@ -99,6 +103,12 @@ export const Trees = () => {
                         text='SVG'
                         icon={downloadIcon}
                         download={true}
+                        newTab={true}
+                    />
+                    <LinkButton
+                        link={msaTaxoniumLink}
+                        text='Tree viewer'
+                        icon={externalLinkIcon}
                         newTab={true}
                     />
                     <LinkButton

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -62,11 +62,10 @@ export const Trees = () => {
         JSON.stringify(reactMsaViewParams)
     )}#`
 
-    const msaTaxoniumConfig = { title: "Serratus: " + selected[searchLevel] }
-    const msaTaxoniumLink = `https://taxonium.org/?treeUrl=${encodeURIComponent(msaNewickLink)}&ladderizeTree=false&config=${encodeURIComponent(
-        JSON.stringify(msaTaxoniumConfig)
-    )}`
-
+    const msaTaxoniumConfig = { title: 'Serratus: ' + selected[searchLevel] }
+    const msaTaxoniumLink = `https://taxonium.org/?treeUrl=${encodeURIComponent(
+        msaNewickLink
+    )}&ladderizeTree=false&config=${encodeURIComponent(JSON.stringify(msaTaxoniumConfig))}`
 
     return (
         <>

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -134,7 +134,7 @@ export const Trees = () => {
                         }>
                         <div className='text-center my-2'>
                             Some of these trees are large. To read tip labels, use the buttons above
-                            to open the external MSA Viewer or download the SVG.
+                            to open the external MSA Viewer, Tree Viewer, or download the SVG.
                         </div>
                         <img
                             className='w-3/4 lg:w-1/3'


### PR DESCRIPTION
Hello, I have developed [a tool](https://taxonium.org/) for exploring large trees, largely [for SARS-CoV-2](https://cov2tree.org/). I was considering other projects that might benefit from such a tool, and Serratus seemed a possible candidate.

This PR would add a button that enables exploring any of the trees interactively using Taxonium.
![image](https://user-images.githubusercontent.com/19732295/168671524-04fae0e3-b96b-4d02-90d5-74c6948a4cb4.png)


E.g. [Levivirales](https://taxonium.org/?treeUrl=https%3A%2F%2Fs3.amazonaws.com%2Fserratus.io%2Ftrees-2021-11-27%2Fnewick%2FLevivirales.newick&ladderizeTree=false&config=%7B%22title%22%3A%22Serratus%3A%20Levivirales%22%7D) (62k nodes)
[Coronaviridae](https://taxonium.org/?treeUrl=https%3A%2F%2Fs3.amazonaws.com%2Fserratus.io%2Ftrees-2021-11-27%2Fnewick%2FCoronaviridae.newick&ladderizeTree=false&config=%7B%22title%22%3A%22Serratus%3A%20Coronaviridae%22%7D) (161 nodes)

No worries if you don't think it's a useful change!