### PR TITLE
Bumped the number of PalmID requests

### DIFF
--- a/src/components/Palmid/Palmid.tsx
+++ b/src/components/Palmid/Palmid.tsx
@@ -202,7 +202,7 @@ export const Palmid = () => {
             {isCheckReportTimedOut && !isReportReady && (
                 <div className='m-4 p-4 flex flex-col items-center justify-center'>
                     <p className='text-yellow-900 text-xl animate-pulse'>Request timed out...</p>
-                    <p> No viral RdRP identified in input sequence (or a server error occured). </p>
+                    <p>palmID server has run out of resources. Please try this job locally.</p>
                     <br />
                     <p>
                         If you think this is an error, please{' '}

--- a/src/components/Palmid/hooks/useFasta.tsx
+++ b/src/components/Palmid/hooks/useFasta.tsx
@@ -33,6 +33,8 @@ export function useFasta(): FastaHook {
     }
 
     useEffect(() => {
+        // This translates to 120 requests * 5 seconds per request = 10 minutes.
+        // This should represent the maximum execution time of the Lambda function.
         if (checkReportRequestCount >= 120) {
             setIsCheckReportTimedOut(true)
         }

--- a/src/components/Palmid/hooks/useFasta.tsx
+++ b/src/components/Palmid/hooks/useFasta.tsx
@@ -33,7 +33,7 @@ export function useFasta(): FastaHook {
     }
 
     useEffect(() => {
-        if (checkReportRequestCount >= 60) {
+        if (checkReportRequestCount >= 120) {
             setIsCheckReportTimedOut(true)
         }
     }, [checkReportRequestCount])


### PR DESCRIPTION
### Summary of changes

The number of requests before a timeout is bumped from 60 to 120. 

### Checklist

- [x] Add tests or provide evidence of manual testing (if applicable)
- [ ] PR checks pass (see [CONTRIBUTING.md](https://github.com/serratus-bio/serratus.io/blob/HEAD/CONTRIBUTING.md) for how to fix failing checks)

### Manual testing
Here's an example of a sequence that used to fail on a 60-request timeout limit: 
```
>betaflax_sativa
SNQFNDMKTLRGKNWNNYVYVFETIYPRHQSSDDLTFFAAIQKRLLRSNP
EKEARKLEKSWGIGSIMFHELKRTLGLNPNVYIDEEVVNREFVQKRLNKS
AKLIENHSGRSDPDWRLDHFFLFMKSQLCTKFEKRFVDAKAGQTLACFSH
QILTRFGVAFRTFEKKFSANLPKTWYVHTMKNFDQLNLWACENVKEREGT
ESDYEAFDRSQDAPILAFEILMLRFFNWPEDLIQDYKMIKLWMGCRLGAV
AIMRFTGEFGTFFFNTLVNMAFTVMRYHVNKESVIAFAGDDMYAAGFLKR
RVDLEFALDQLTLKAKVQFTRRPMFCGWYMTPMGIVKEPRLVLERWKIAE
QKGNLRDVIINYALEVSYGYRLGEYLWEVLDNLESQQEIVRNIVKSKHLL
PLKVRHFFSAVDNETLSTEF
```
After increasing the request limit, an error report was returned as expected here: https://s3.amazonaws.com/openvirome.com/betaflax_sativa.html

In addition to the change made here, the timeout for the PalmID Lambda API function was also bumped from 5 minutes to 10 minutes.