### PR TITLE
Add palmID aa-bug warning

### DIFF
--- a/src/components/Palmid/Palmid.tsx
+++ b/src/components/Palmid/Palmid.tsx
@@ -144,7 +144,7 @@ export const Palmid = () => {
                     !isFastaCollapsed ? 'collapsed' : 'expanded'
                 }`}
                 aria-expanded={isFastaCollapsed}>
-                <p className='my-3'>Sequence, in FASTA format</p>
+                <p className='my-3'>Sequence, in FASTA format (known bug: only amino-acid supported currently)</p>
                 <textarea
                     className='border-2 focus:ring-1 rounded focus: outline-none resize-none  mb-2 p-2'
                     id='fastaInput'

--- a/src/components/Palmid/Palmid.tsx
+++ b/src/components/Palmid/Palmid.tsx
@@ -144,7 +144,7 @@ export const Palmid = () => {
                     !isFastaCollapsed ? 'collapsed' : 'expanded'
                 }`}
                 aria-expanded={isFastaCollapsed}>
-                <p className='my-3'>Sequence, in FASTA format (known bug: only amino-acid supported currently)</p>
+                <p className='my-3'>Sequence, in FASTA format (bug: only aa-sequence supported)</p>
                 <textarea
                     className='border-2 focus:ring-1 rounded focus: outline-none resize-none  mb-2 p-2'
                     id='fastaInput'


### PR DESCRIPTION
Add short text label to use only `amino acid` input for palmId currently until bug is fixed.