### PR TITLE
Integrate MapPlot with RdRP geo API

### DIFF
--- a/src/components/Explorer/Base/Result/SerratusApiCalls.tsx
+++ b/src/components/Explorer/Base/Result/SerratusApiCalls.tsx
@@ -95,6 +95,17 @@ export const fetchPagedRunMatches = async (
     return response.data as ResultPagination
 }
 
+export const fetchPagedGeoMatches = async (searchType: string, page: number, perPage: number) => {
+    const params: any = {
+        page: page,
+        perPage: perPage,
+    }
+    const response = await axios.get(`${baseUrl}/geo/${searchType}/paged`, {
+        params: params,
+    })
+    return response.data as ResultPagination
+}
+
 export const getPalmprintInfo = async (runId: string) => {
     const palmprintUrl = `${baseUrl}/palmprint/run=${runId}`
     const response = await axios.get(palmprintUrl)

--- a/src/components/Geo/Geo.tsx
+++ b/src/components/Geo/Geo.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Helmet } from 'react-helmet'
-import { MapPlot } from './MapPlot'
+import { MemoizedMapPlot } from './MapPlot'
 import { SelectionInfo } from './SelectionInfo'
 import { RunData } from './types'
 import { helpIcon } from 'common'
@@ -42,7 +42,7 @@ export const Geo = () => {
             </div>
 
             <div className='my-2'>
-                <MapPlot setSelectedPoints={setSelectedPoints} />
+                <MemoizedMapPlot setSelectedPoints={setSelectedPoints} />
             </div>
 
             <div className='text-left text-gray-600'>

--- a/src/components/Geo/MapPlot.tsx
+++ b/src/components/Geo/MapPlot.tsx
@@ -1,90 +1,11 @@
 import React from 'react'
 import Plotly from 'plotly.js'
 import Plot from 'react-plotly.js'
-import * as d3 from 'd3'
 import { RunData } from './types'
-import rdrpPosTsv from './rdrp_pos.tsv'
+import { fetchPagedGeoMatches } from 'components/Explorer/Base/Result/SerratusApiCalls'
 
 type Props = {
     setSelectedPoints: React.Dispatch<React.SetStateAction<RunData[] | undefined>>
-}
-
-export const MapPlot = ({ setSelectedPoints }: Props) => {
-    const [config, setConfig] = React.useState<{ data: PlotlyData[] }>({
-        data: [],
-    })
-
-    React.useEffect(() => {
-        async function render() {
-            setConfig({ data: await getData() })
-        }
-        render()
-    }, [])
-
-    if (!config.data || !config.data.length) return null
-
-    function onSelected(selectedData: Readonly<Plotly.PlotSelectionEvent>) {
-        // TODO: use type annotation
-        const points = selectedData.points.map((point) => point.customdata) as RunData[]
-        setSelectedPoints(points)
-    }
-
-    return (
-        <Plot
-            data={config.data}
-            layout={layout}
-            useResizeHandler
-            style={{ width: '100%', height: '100%', minHeight: '500px' }}
-            onSelected={onSelected}
-            onUpdate={(figure) => setConfig(figure)}
-        />
-    )
-}
-
-const layout: Partial<Plotly.Layout> = {
-    mapbox: { style: 'open-street-map', zoom: 1, pitch: 15 },
-    margin: { t: 0, b: 0, l: 0, r: 0 },
-    autosize: true,
-    clickmode: 'event+select',
-}
-
-async function getData(): Promise<PlotlyData[]> {
-    // TODO: use type annotation
-    const rows = ((await d3.tsv(rdrpPosTsv)) as object) as RunData[]
-    function unpack(rows: RunData[], key: string) {
-        return rows.map((row) => {
-            if (key === 'coordinate_x' || key === 'coordinate_y') {
-                // +(0~111) meters per https://www.usna.edu/Users/oceano/pguth/md_help/html/approx_equivalents.htm
-                return parseFloat(row[key]) + 0.001 * Math.random()
-            }
-            return row[key]
-        })
-    }
-
-    function getHoverText(rows: RunData[]): string[] {
-        return rows.map((row) => {
-            let text = `${row.run_id}
-                <br>Organism: ${row.scientific_name}`
-            if (row.from_text) {
-                text += `<br>Inferred location: "${row.from_text}"`
-            }
-            return text
-        })
-    }
-
-    return [
-        {
-            type: 'scattermapbox',
-            lon: unpack(rows, 'coordinate_x'),
-            lat: unpack(rows, 'coordinate_y'),
-            mode: 'markers',
-            customdata: rows,
-            text: getHoverText(rows),
-            hoverinfo: 'text',
-            marker: { color: 'Maroon', size: 5, opacity: 1 },
-            selected: { marker: { color: 'Purple', size: 7, opacity: 1 } },
-        },
-    ]
 }
 
 // temp fix pending https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44030
@@ -95,3 +16,131 @@ type PlotlyData = Plotly.Data &
             textfont: Partial<Plotly.Font>
         }>
     }>
+
+const MapPlot = ({ setSelectedPoints }: Props) => {
+    const [geoPaginatedDated, setGeoPaginatedData] = React.useState<{
+        [page: string]: Partial<Plotly.PlotData>
+    }>({})
+
+    const layoutConfig: Partial<Plotly.Layout> = {
+        mapbox: { style: 'open-street-map', zoom: 1, pitch: 0 },
+        margin: { t: 0, b: 0, l: 0, r: 0 },
+        autosize: true,
+        clickmode: 'event+select',
+    }
+
+    React.useEffect(() => {
+        async function render() {
+            fetchData()
+        }
+        render()
+    }, [])
+
+    function onSelected(selectedData: Readonly<Plotly.PlotSelectionEvent>) {
+        // TODO: use type annotation
+        const points = selectedData.points.map((point) => point.customdata) as RunData[]
+        setSelectedPoints(points)
+    }
+
+    async function fetchData() {
+        // Fetch first page to get total
+        let page = 1
+        const perPage = 20000
+        const searchType = 'rdrp'
+        const { result, total } = await fetchPagedGeoMatches(searchType, page, perPage)
+        transformAndStoreGeoData(result as RunData[], page)
+
+        // Batch requests for remaining pages
+        const totalPages = Math.ceil(total / perPage)
+        const iterPages = []
+        for (page = page + 1; page <= totalPages; page++) {
+            if (!(page in geoPaginatedDated)) {
+                iterPages.push(page)
+            }
+        }
+        await Promise.allSettled(
+            iterPages.map(async (page) => {
+                const { result } = await fetchPagedGeoMatches(searchType, page as number, perPage)
+                transformAndStoreGeoData(result as RunData[], page as number)
+            })
+        )
+    }
+
+    function transformAndStoreGeoData(rows: RunData[], page: number) {
+        if (!rows.length) {
+            return
+        }
+        function transformCoordinates(rows: RunData[], key: string) {
+            return rows.map((row) => {
+                if (key === 'coordinate_x' || key === 'coordinate_y') {
+                    // +(0~111) meters per https://www.usna.edu/Users/oceano/pguth/md_help/html/approx_equivalents.htm
+                    return parseFloat(row[key]) + 0.001 * Math.random()
+                }
+                return row[key]
+            })
+        }
+        function getHoverText(rows: RunData[]): string[] {
+            return rows.map((row) => {
+                let text = `${row.run_id}
+                    <br>Organism: ${row.scientific_name}`
+                if (row.from_text) {
+                    text += `<br>Inferred location: "${row.from_text}"`
+                }
+                return text
+            })
+        }
+        setGeoPaginatedData((prevState) => ({
+            ...prevState,
+            [page]: {
+                lon: transformCoordinates(rows, 'coordinate_x'),
+                lat: transformCoordinates(rows, 'coordinate_y'),
+                customdata: rows,
+                text: getHoverText(rows),
+            },
+        }))
+    }
+
+    function mergePaginatedGeoData(): Partial<Plotly.PlotData>[] {
+        const mapConfig: PlotlyData = {
+            type: 'scattermapbox',
+            mode: 'markers',
+            hoverinfo: 'text',
+            marker: { color: 'Maroon', size: 5, opacity: 1 },
+            selected: { marker: { color: 'Purple', size: 7, opacity: 1 } },
+        }
+        const geoData: Partial<Plotly.PlotData> = {
+            lon: [],
+            lat: [],
+            customdata: [],
+            text: [],
+        }
+        for (const [, row] of Object.entries(geoPaginatedDated)) {
+            row?.lon && geoData?.lon?.push(...row.lon)
+            row?.lat && geoData?.lat?.push(...row.lat)
+            row?.customdata && geoData?.customdata?.push(...(row.customdata as any))
+            row?.text &&
+                typeof row?.text === 'object' &&
+                typeof geoData?.text === 'object' &&
+                geoData?.text?.push(...row.text)
+        }
+        return [
+            {
+                ...mapConfig,
+                ...geoData,
+            },
+        ]
+    }
+
+    return (
+        <Plot
+            revision={1}
+            data={mergePaginatedGeoData()}
+            layout={layoutConfig}
+            useResizeHandler
+            style={{ width: '100%', height: '100%', minHeight: '500px' }}
+            onSelected={onSelected}
+        />
+    )
+}
+
+export const MemoizedMapPlot = React.memo(MapPlot)


### PR DESCRIPTION
### Summary of changes

- Integrate MapPlot with paginated geo endpoint (https://github.com/serratus-bio/serratus-summary-api/pull/37)
- Note, given the large number of geo points (93034 rows) it will be important that the server caches results.

<!-- Update the PR title and describe your changes here. -->

### Related issues

https://github.com/serratus-bio/serratus.io/issues/225

<!-- Link any related issues here.
See <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>
-->

### Checklist

- [x] Add tests or provide evidence of manual testing (if applicable)
- [x] PR checks pass (see [CONTRIBUTING.md](https://github.com/serratus-bio/serratus.io/blob/HEAD/CONTRIBUTING.md) for how to fix failing checks)

Manual testing:
    - Check all data-points are fetched and rendered on map
    - Select single and multiple points with shift+click and lasso

