### PR TITLE
Update matches download URL

### DIFF
--- a/src/components/Explorer/Base/Result/SerratusApiCalls.tsx
+++ b/src/components/Explorer/Base/Result/SerratusApiCalls.tsx
@@ -26,7 +26,7 @@ export const getMatchesDownloadUrl = (
         [searchLevel]: searchLevelValue,
     }
     const urlParams = new URLSearchParams(params)
-    return `${baseUrl}/matches/${searchType}?${urlParams}`
+    return `${baseUrl}/matches/${searchType}/download?${urlParams}`
 }
 
 export const fetchPagedMatches = async (


### PR DESCRIPTION
### Summary of changes

<!-- Update the PR title and describe your changes here. -->
- This is needed to support fetching all run_ids instead of using pagination route
- Renaming the download route in order to replace the existing matches route to return JSON
- New route has been deployed: https://github.com/serratus-bio/serratus-summary-api/pull/46
   - can test URL: https://api.serratus.io/matches/rdrp/download?scoreMin=50&scoreMax=100&identityMin=45&identityMax=100&family=Alphaflexiviridae

### Related issues

<!-- Link any related issues here.
See <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>
-->

### Checklist

- [x] Add tests or provide evidence of manual testing (if applicable)
- [x] PR checks pass (see [CONTRIBUTING.md](https://github.com/serratus-bio/serratus.io/blob/HEAD/CONTRIBUTING.md) for how to fix failing checks)
