### PR TITLE
Add Geo tab to explorer pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "react-router-dom": "^5.2.0",
                 "react-scripts": "^4.0.3",
                 "react-select": "^3.1.0",
+                "react-tabs": "^4.2.1",
                 "react-windowed-select": "^5.1.0"
             },
             "devDependencies": {
@@ -37,6 +38,7 @@
                 "@types/react-plotly.js": "^2.2.4",
                 "@types/react-router-dom": "^5.1.7",
                 "@types/react-select": "^4.0.16",
+                "@types/react-tabs": "^2.3.4",
                 "@types/react-window": "^1.8.5",
                 "@typescript-eslint/eslint-plugin": "^4.28.0",
                 "@typescript-eslint/parser": "^4.28.0",
@@ -4537,6 +4539,15 @@
                 "@types/react": "*",
                 "@types/react-dom": "*",
                 "@types/react-transition-group": "*"
+            }
+        },
+        "node_modules/@types/react-tabs": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.4.tgz",
+            "integrity": "sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==",
+            "dev": true,
+            "dependencies": {
+                "@types/react": "*"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -18566,6 +18577,18 @@
                 "react": ">= 0.14.0"
             }
         },
+        "node_modules/react-tabs": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.2.1.tgz",
+            "integrity": "sha512-nQcEN3KrAsSry6f9Jz2oyMQsnh+sLEy31YjlskL/mnI3KU/c7BeyD1VzHZmmcJ15UEFu12pYOXYkdTzZ0uyIbw==",
+            "dependencies": {
+                "clsx": "^1.1.0",
+                "prop-types": "^15.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-0 || ^18.0.0"
+            }
+        },
         "node_modules/react-transition-group": {
             "version": "4.4.5",
             "license": "BSD-3-Clause",
@@ -27473,6 +27496,15 @@
                 "@types/react": "*",
                 "@types/react-dom": "*",
                 "@types/react-transition-group": "*"
+            }
+        },
+        "@types/react-tabs": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.4.tgz",
+            "integrity": "sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
             }
         },
         "@types/react-transition-group": {
@@ -37095,6 +37127,15 @@
                 "lowlight": "^1.14.0",
                 "prismjs": "^1.21.0",
                 "refractor": "^3.1.0"
+            }
+        },
+        "react-tabs": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.2.1.tgz",
+            "integrity": "sha512-nQcEN3KrAsSry6f9Jz2oyMQsnh+sLEy31YjlskL/mnI3KU/c7BeyD1VzHZmmcJ15UEFu12pYOXYkdTzZ0uyIbw==",
+            "requires": {
+                "clsx": "^1.1.0",
+                "prop-types": "^15.5.0"
             }
         },
         "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "^4.0.3",
         "react-select": "^3.1.0",
+        "react-tabs": "^4.2.1",
         "react-windowed-select": "^5.1.0"
     },
     "scripts": {
@@ -56,6 +57,7 @@
         "@types/react-plotly.js": "^2.2.4",
         "@types/react-router-dom": "^5.1.7",
         "@types/react-select": "^4.0.16",
+        "@types/react-tabs": "^2.3.4",
         "@types/react-window": "^1.8.5",
         "@typescript-eslint/eslint-plugin": "^4.28.0",
         "@typescript-eslint/parser": "^4.28.0",

--- a/src/common/LoadIcon.tsx
+++ b/src/common/LoadIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+export const LoadIcon = () => {
+    const elementRef = React.useRef(null)
+
+    React.useEffect(() => {
+        if (!elementRef?.current) {
+            return
+        }
+        const divElement = elementRef?.current as HTMLElement
+        divElement?.classList.add('opacity-100')
+    }, [elementRef])
+
+    return (
+        <div
+            ref={elementRef}
+            className='flex flex-col items-center content-center justify-center w-full h-full opacity-0 transition-opacity ease-in duration-700'>
+            <div className='text-center my-4'>Loading... (this might take a while)</div>
+            <img className='w-36 h-36' src='/load_palmid.gif' alt='Loading gif' />
+        </div>
+    )
+}

--- a/src/components/Explorer/Base/Result/MatchChart/MatchChartController.tsx
+++ b/src/components/Explorer/Base/Result/MatchChart/MatchChartController.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ExternalLink } from 'common'
 import { IMatchChart } from './IMatchChart'
 import { ResultPagination } from '../types'
+import { LoadIcon } from 'common/LoadIcon'
 
 type Props = {
     dataPromise: Promise<ResultPagination> | undefined
@@ -25,8 +26,6 @@ export const MatchChartController = ({ dataPromise, chart }: Props) => {
             })
     }, [dataPromise])
 
-    const loading = <div className='text-center'>Loading... (this might take a while)</div>
-
     const noResults = (
         <div className='text-center'>
             <span>This search did not return any results.</span>
@@ -43,7 +42,7 @@ export const MatchChartController = ({ dataPromise, chart }: Props) => {
 
     if (isLoading) {
         // use component from React before chart component has been returned
-        if (!chart.componentLoaded) return loading
+        if (!chart.componentLoaded) return <LoadIcon />
         chart.setLoading()
         return chart.component
     }

--- a/src/components/Explorer/Base/Result/Result.tsx
+++ b/src/components/Explorer/Base/Result/Result.tsx
@@ -3,6 +3,7 @@ import { FamilyMatches } from './FamilyMatches'
 import { SequenceMatches } from './SequenceMatches'
 import { RunLookup } from './RunLookup'
 import { RangeFilter } from 'components/Explorer/types'
+import { withTabs } from './withTabs'
 
 type Props = {
     searchLevel: string
@@ -20,10 +21,20 @@ export const Result = ({ searchLevel, searchLevelValue, identityLims, scoreLims 
         return <RunLookup runId={searchLevelValue} filters={filters} />
     }
     if (searchLevel === 'sequence') {
-        return <SequenceMatches sequenceId={searchLevelValue} filters={filters} />
+        return withTabs({
+            component: <SequenceMatches sequenceId={searchLevelValue} filters={filters} />,
+            searchLevel,
+            searchLevelValue,
+            filters,
+        })
     }
     if (searchLevel === 'family') {
-        return <FamilyMatches familyName={searchLevelValue} filters={filters} />
+        return withTabs({
+            component: <FamilyMatches familyName={searchLevelValue} filters={filters} />,
+            searchLevel,
+            searchLevelValue,
+            filters,
+        })
     }
     return null
 }

--- a/src/components/Explorer/Base/Result/RunLookup/PalmPrintsTable.tsx
+++ b/src/components/Explorer/Base/Result/RunLookup/PalmPrintsTable.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { routes } from 'common/routes'
 import { filterObjects } from 'common/utils'
+import { externalLinkIcon } from 'common'
 
 interface PalmPrintsTableProps {
     data: any[] | undefined
@@ -68,7 +69,8 @@ export const PalmPrintsTable = ({ data, header }: PalmPrintsTableProps) => {
                                                                             <NavLink
                                                                                 className='text-blue-600 dark:text-blue-500 hover:underline'
                                                                                 to={`${routes.palmid.path}?fastaInput=%3E${data[eIndex]['run_id']}_${data[eIndex]['assembly_node']}_${data[eIndex]['palm_id']}%0A${data[eIndex]['q_sequence']}`}>
-                                                                                Analyse
+                                                                                Palmprint{' '}
+                                                                                {externalLinkIcon}
                                                                             </NavLink>
                                                                         </td>
                                                                     </>

--- a/src/components/Explorer/Base/Result/RunLookup/PalmPrintsTable.tsx
+++ b/src/components/Explorer/Base/Result/RunLookup/PalmPrintsTable.tsx
@@ -69,7 +69,7 @@ export const PalmPrintsTable = ({ data, header }: PalmPrintsTableProps) => {
                                                                             <NavLink
                                                                                 className='text-blue-600 dark:text-blue-500 hover:underline'
                                                                                 to={`${routes.palmid.path}?fastaInput=%3E${data[eIndex]['run_id']}_${data[eIndex]['assembly_node']}_${data[eIndex]['palm_id']}%0A${data[eIndex]['q_sequence']}`}>
-                                                                                Palmprint{' '}
+                                                                                palmID{' '}
                                                                                 {externalLinkIcon}
                                                                             </NavLink>
                                                                         </td>

--- a/src/components/Explorer/Base/Result/SerratusApiCalls.tsx
+++ b/src/components/Explorer/Base/Result/SerratusApiCalls.tsx
@@ -29,6 +29,27 @@ export const getMatchesDownloadUrl = (
     return `${baseUrl}/matches/${searchType}/download?${urlParams}`
 }
 
+export const fetchMatches = async (
+    searchType: string,
+    searchLevel: string,
+    searchLevelValue: string,
+    filters: Filters,
+    columns: string[]
+) => {
+    const [identityMin, identityMax] = filters.identityLims
+    const [scoreMin, scoreMax] = filters.scoreLims
+    const params = {
+        scoreMin: scoreMin.toString(),
+        scoreMax: scoreMax.toString(),
+        identityMin: identityMin.toString(),
+        identityMax: identityMax.toString(),
+        [searchLevel]: searchLevelValue,
+        columns: columns.join(','),
+    }
+    const response = await axios.get(`${baseUrl}/matches/${searchType}`, { params })
+    return response.data
+}
+
 export const fetchPagedMatches = async (
     searchType: string,
     searchLevel: string,
@@ -95,10 +116,16 @@ export const fetchPagedRunMatches = async (
     return response.data as ResultPagination
 }
 
-export const fetchPagedGeoMatches = async (searchType: string, page: number, perPage: number) => {
+export const fetchPagedGeoMatches = async (
+    searchType: string,
+    page: number,
+    perPage: number,
+    runIds?: string[]
+) => {
     const params: any = {
         page: page,
         perPage: perPage,
+        run: runIds?.length ? runIds.join(',') : '',
     }
     const response = await axios.get(`${baseUrl}/geo/${searchType}/paged`, {
         params: params,

--- a/src/components/Explorer/Base/Result/withTabs.tsx
+++ b/src/components/Explorer/Base/Result/withTabs.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Geo } from 'components/Geo'
+import { BaseContext } from 'components/Explorer/Base/BaseContext'
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
+import { Filters } from 'components/Explorer/types'
+import { fetchMatches } from './SerratusApiCalls'
+import 'react-tabs/style/react-tabs.css'
+
+type Props = {
+    component: React.ReactElement
+    searchLevel: string
+    searchLevelValue: string
+    filters: Filters
+}
+
+export const withTabs = ({ component, searchLevel, searchLevelValue, filters }: Props) => {
+    const context = React.useContext(BaseContext)
+    const [runIds, setRunIds] = React.useState<string[]>([])
+
+    React.useEffect(() => {
+        async function onMount() {
+            const runIds = await fetchMatches(
+                context.searchType,
+                searchLevel,
+                searchLevelValue,
+                filters,
+                ['run_id']
+            )
+            setRunIds(runIds.map((row: any) => row.run_id))
+        }
+        onMount()
+    }, [])
+
+    const loading = <div className='text-center'>Loading... (this might take a while)</div>
+
+    return (
+        <Tabs>
+            <TabList>
+                <Tab>Sequence</Tab>
+                <Tab disabled={runIds.length === 0}>Geo</Tab>
+            </TabList>
+            <TabPanel>{component}</TabPanel>
+            <TabPanel>{runIds.length ? <Geo runIds={runIds} /> : loading}</TabPanel>
+        </Tabs>
+    )
+}

--- a/src/components/Explorer/Base/Result/withTabs.tsx
+++ b/src/components/Explorer/Base/Result/withTabs.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Geo } from 'components/Geo'
 import { BaseContext } from 'components/Explorer/Base/BaseContext'
-import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
+import { LoadIcon } from 'common/LoadIcon'
 import { Filters } from 'components/Explorer/types'
 import { fetchMatches } from './SerratusApiCalls'
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import 'react-tabs/style/react-tabs.css'
 
 type Props = {
@@ -31,8 +32,6 @@ export const withTabs = ({ component, searchLevel, searchLevelValue, filters }: 
         onMount()
     }, [])
 
-    const loading = <div className='text-center'>Loading... (this might take a while)</div>
-
     return (
         <Tabs>
             <TabList>
@@ -40,7 +39,9 @@ export const withTabs = ({ component, searchLevel, searchLevelValue, filters }: 
                 <Tab disabled={runIds.length === 0}>Geo</Tab>
             </TabList>
             <TabPanel>{component}</TabPanel>
-            <TabPanel>{runIds.length ? <Geo runIds={runIds} /> : loading}</TabPanel>
+            <TabPanel>
+                {runIds.length ? <Geo isEmbedded={true} runIds={runIds} /> : <LoadIcon />}
+            </TabPanel>
         </Tabs>
     )
 }

--- a/src/components/Geo/Geo.tsx
+++ b/src/components/Geo/Geo.tsx
@@ -17,7 +17,11 @@ import {
 import { SpeciesSelect } from './SpeciesSelect'
 import { TimePlot } from './TimePlot'
 
-export const Geo = () => {
+type Props = {
+    runIds?: string[]
+}
+
+export const Geo = ({ runIds }: Props) => {
     const [isCollapsed, setIsCollapsed] = React.useState<boolean>(false)
     const [isFetching, setIsFetching] = React.useState<boolean>(true)
     const [paginatedRunData, setPaginatedRunData] = React.useState<{
@@ -25,6 +29,15 @@ export const Geo = () => {
     }>({})
     const [selectedPoints, setSelectedPoints] = React.useState<RunData[]>([])
     const [selectedSpecies, setSelectedSpecies] = React.useState<string[]>([])
+
+    const shouldFetchAll = () => !runIds || runIds?.length === 0 || runIds?.length > 100
+
+    React.useEffect(() => {
+        async function onMount() {
+            fetchRunData()
+        }
+        onMount()
+    }, [])
 
     React.useEffect(() => {
         async function onMount() {
@@ -50,7 +63,8 @@ export const Geo = () => {
         let page = 1
         const perPage = 20000
         const searchType = 'rdrp'
-        const { result, total } = await fetchPagedGeoMatches(searchType, page, perPage)
+        const queryRunIds = shouldFetchAll() ? [] : runIds
+        const { result, total } = await fetchPagedGeoMatches(searchType, page, perPage, queryRunIds)
         storePaginatedRunData(result as RunData[], page)
 
         // Batch requests for remaining pages
@@ -63,15 +77,23 @@ export const Geo = () => {
         }
         await Promise.allSettled(
             iterPages.map(async (page) => {
-                const { result } = await fetchPagedGeoMatches(searchType, page as number, perPage)
+                const { result } = await fetchPagedGeoMatches(
+                    searchType,
+                    page as number,
+                    perPage,
+                    queryRunIds
+                )
                 storePaginatedRunData(result as RunData[], page as number)
             })
         )
         setIsFetching(false)
     }
 
+    const runData = React.useMemo(() => {
+        return getRunDataFromPaginatedData(paginatedRunData, shouldFetchAll() ? runIds : [])
+    }, [isFetching])
+
     const speciesOptions = React.useMemo(() => {
-        const runData = getRunDataFromPaginatedData(paginatedRunData)
         const filteredBySelectedPoints = filterRunDataByGroup(
             runData,
             getBioIdsFromRunData(selectedPoints),
@@ -81,10 +103,9 @@ export const Geo = () => {
             filteredBySelectedPoints.map((d) => d?.[RunDataKey.ScientificName])
         )
         return Array.from(speciesSet).sort()
-    }, [isFetching, selectedPoints, selectedSpecies])
+    }, [runData, selectedPoints, selectedSpecies])
 
     const filteredAndSelectedRows = React.useMemo(() => {
-        const runData = getRunDataFromPaginatedData(paginatedRunData)
         if (runData.length === 0) {
             return []
         }
@@ -98,10 +119,9 @@ export const Geo = () => {
             getBioIdsFromRunData(selectedPoints),
             RunDataKey.BiosampleId
         )
-    }, [isFetching, selectedSpecies, selectedPoints])
+    }, [runData, selectedSpecies, selectedPoints])
 
     const mapData = React.useMemo(() => {
-        const runData = getRunDataFromPaginatedData(paginatedRunData)
         const filteredBySpecies = filterRunDataByGroup(
             runData,
             selectedSpecies,
@@ -118,7 +138,7 @@ export const Geo = () => {
             selectedSpecies,
             getBioIdsFromRunData(selectedPoints)
         )
-    }, [isFetching, selectedSpecies, selectedPoints])
+    }, [runData, selectedSpecies, selectedPoints])
 
     const timePlotData = React.useMemo(() => {
         const groupedCounter = countRunDataByDateAndKey(
@@ -128,49 +148,73 @@ export const Geo = () => {
         return transformToTimePlotData(groupedCounter, selectedSpecies)
     }, [filteredAndSelectedRows])
 
+    const loading = <div className='text-center'>Loading... (this might take a while)</div>
+
     return (
         <div className='mx-14 my-2'>
             <Helmet>
                 <title>Serratus | Planetary RNA Virome</title>
             </Helmet>
             <div className='text-center text-xl my-4'>The Planetary RNA Virome</div>
-            <button
-                className='text-left collapse-button'
-                onClick={() => setIsCollapsed(!isCollapsed)}>
-                {helpIcon} Info
-            </button>
-            <div
-                className={`collapse-content ${!isCollapsed ? 'collapsed' : 'expanded'}`}
-                aria-expanded={isCollapsed}>
-                <p>
-                    We searched 5.7 million public sequencing libraries for the RNA virus hallmark
-                    gene, RNA-dependent RNA Polymerase (RdRP).
-                </p>
+            {!runData.length || isFetching ? (
+                loading
+            ) : (
+                <>
+                    <div className='flex my-4'>
+                        <button
+                            className='collapse-button'
+                            style={{ color: 'blue' }}
+                            onClick={() => setIsCollapsed(!isCollapsed)}>
+                            <p className='text-left'>{helpIcon} Info</p>
+                        </button>
+                        <p className='text-right w-full'>
+                            {runData.length
+                                ? `Geo data available for ${runData.length}/${
+                                      !runIds || runIds?.length === 0
+                                          ? runData.length
+                                          : runIds?.length
+                                  } runs`
+                                : null}
+                        </p>
+                    </div>
+                    <div
+                        className={`collapse-content ${!isCollapsed ? 'collapsed' : 'expanded'}`}
+                        aria-expanded={isCollapsed}>
+                        <p>
+                            We searched 5.7 million public sequencing libraries for the RNA virus
+                            hallmark gene, RNA-dependent RNA Polymerase (RdRP).
+                        </p>
 
-                <p>
-                    This map shows the location of BioSamples from which an intact RdRP sequence
-                    could be recovered and geographical meta-data was present.
-                </p>
+                        <p>
+                            This map shows the location of BioSamples from which an intact RdRP
+                            sequence could be recovered and geographical meta-data was present.
+                        </p>
 
-                <p>A 100-meter randomization is applied to all points to prevent overplotting.</p>
-            </div>
-            <div className='my-4'>
-                <SpeciesSelect
-                    speciesOptions={speciesOptions}
-                    selectedSpecies={selectedSpecies}
-                    setSelectedSpecies={setSelectedSpecies}
-                />
-            </div>
-            <div className='my-4'>
-                <MapPlot plotData={mapData} setSelectedPoints={setSelectedPoints} />
-            </div>
-            <div className='text-left text-gray-600'>
-                Use <b>`Shift`</b> -click to select multiple points or the <b>`Box Select`</b> or{' '}
-                <b>`Lasso Select`</b> icons in the top-right. <b>Double-click</b> to deselect
-                points.
-            </div>
-            <TimePlot plotData={timePlotData} />
-            <ResultsTable rowsToDisplay={filteredAndSelectedRows} />
+                        <p>
+                            A 100-meter randomization is applied to all points to prevent
+                            overplotting.
+                        </p>
+                    </div>
+
+                    <div className='my-4'>
+                        <SpeciesSelect
+                            speciesOptions={speciesOptions}
+                            selectedSpecies={selectedSpecies}
+                            setSelectedSpecies={setSelectedSpecies}
+                        />
+                    </div>
+                    <div className='my-4'>
+                        <MapPlot plotData={mapData} setSelectedPoints={setSelectedPoints} />
+                    </div>
+                    <div className='text-left text-gray-600'>
+                        <b>`Shift`-click</b> to select multiple points or use the{' '}
+                        <b>`Box Select`</b> or <b>`Lasso Select`</b> icons in the top-right.{' '}
+                        <b>Double-click</b> to deselect points.
+                    </div>
+                    <TimePlot plotData={timePlotData} />
+                    <ResultsTable rowsToDisplay={filteredAndSelectedRows} />
+                </>
+            )}
         </div>
     )
 }

--- a/src/components/Geo/Geo.tsx
+++ b/src/components/Geo/Geo.tsx
@@ -16,12 +16,14 @@ import {
 } from './GeoHelpers'
 import { SpeciesSelect } from './SpeciesSelect'
 import { TimePlot } from './TimePlot'
+import { LoadIcon } from 'common/LoadIcon'
 
 type Props = {
     runIds?: string[]
+    isEmbedded?: boolean
 }
 
-export const Geo = ({ runIds }: Props) => {
+export const Geo = ({ runIds, isEmbedded = false }: Props) => {
     const [isCollapsed, setIsCollapsed] = React.useState<boolean>(false)
     const [isFetching, setIsFetching] = React.useState<boolean>(true)
     const [paginatedRunData, setPaginatedRunData] = React.useState<{
@@ -148,16 +150,18 @@ export const Geo = ({ runIds }: Props) => {
         return transformToTimePlotData(groupedCounter, selectedSpecies)
     }, [filteredAndSelectedRows])
 
-    const loading = <div className='text-center'>Loading... (this might take a while)</div>
-
     return (
         <div className='mx-14 my-2'>
-            <Helmet>
-                <title>Serratus | Planetary RNA Virome</title>
-            </Helmet>
-            <div className='text-center text-xl my-4'>The Planetary RNA Virome</div>
+            {isEmbedded ? null : (
+                <>
+                    <Helmet>
+                        <title>Serratus | Planetary RNA Virome</title>
+                    </Helmet>
+                    <div className='text-center text-xl my-4'>The Planetary RNA Virome</div>
+                </>
+            )}
             {!runData.length || isFetching ? (
-                loading
+                <LoadIcon />
             ) : (
                 <>
                     <div className='flex my-4'>

--- a/src/components/Geo/GeoHelpers.tsx
+++ b/src/components/Geo/GeoHelpers.tsx
@@ -74,7 +74,7 @@ function convertMapCoordinates(row: RunData, key: string) {
 
 function getMapHoverText(row: RunData): string {
     let text = `${row.run_id}
-        <br>Organism: ${row[RunDataKey.ScientificName]}`
+        <br>Scientific Name: ${row[RunDataKey.ScientificName]}`
     if (row.from_text) {
         text += `<br>Inferred location: "${row.from_text}"`
     }
@@ -187,17 +187,26 @@ export function transformToTimePlotData(
     }
     return selectedSpecies.map((speciesName) => {
         const color = getColorFromSelectedIndex(speciesName, selectedSpecies)
+        const xValues = []
+        const yValues = []
+        for (const [date, counter] of Object.entries(dateCounter)) {
+            if (counter[speciesName]) {
+                xValues.push(date)
+                yValues.push(counter[speciesName])
+            }
+        }
         return {
-            x: Object.keys(dateCounter),
-            y: Object.values(dateCounter).map((counter) => counter[speciesName] ?? 0),
-            name: speciesName,
+            x: xValues,
+            y: yValues,
             type: 'bar',
             marker: { color: color },
             showlegend: false,
+            name: speciesName,
             hovertemplate:
-                `<b>Scientific Name: </b>${speciesName}<br>` +
+                `<b>Scientific Name</b>: ${speciesName}<br>` +
                 '<b>Month</b>: %{x}<br>' +
-                '<b>Count Per Month: </b>%{y}',
+                '<b>Count Per Month: </b>%{y}' +
+                `<extra></extra>`,
         }
     })
 }

--- a/src/components/Geo/GeoHelpers.tsx
+++ b/src/components/Geo/GeoHelpers.tsx
@@ -19,8 +19,17 @@ export function getColorFromSelectedIndex(
     return selectedIndex >= 0 ? getColorFromIndex(selectedIndex) : defaultColor
 }
 
-export function getRunDataFromPaginatedData(paginatedRunData: { [page: string]: RunData[] }) {
-    return Object.values(paginatedRunData).flat()
+export function getRunDataFromPaginatedData(
+    paginatedRunData: { [page: string]: RunData[] },
+    filterRunIds?: string[]
+) {
+    const results = Object.values(paginatedRunData).flat()
+    if (!filterRunIds || filterRunIds?.length === 0) {
+        return results
+    }
+    const set = new Set(filterRunIds)
+
+    return results.filter((row) => set.has(row.run_id))
 }
 
 export function getBioIdsFromRunData(selectedPoints: RunData[]) {

--- a/src/components/Geo/MapPlot.tsx
+++ b/src/components/Geo/MapPlot.tsx
@@ -23,7 +23,7 @@ export const MapPlot = ({ setSelectedPoints, plotData }: Props) => {
     })
 
     React.useEffect(() => {
-        setConfig((prevConfig) => ({ ...prevConfig, data: plotData }))
+        setConfig((prevState) => ({ ...prevState, data: plotData }))
     }, [plotData])
 
     function onSelected(selectedData: Readonly<Plotly.PlotSelectionEvent>) {
@@ -43,7 +43,12 @@ export const MapPlot = ({ setSelectedPoints, plotData }: Props) => {
                     data: plotData,
                 } as PlotParams)
             }
-            onUpdate={(figure) => setConfig(figure as PlotParams)}
+            onUpdate={(figure) =>
+                setConfig({
+                    ...figure,
+                    data: plotData,
+                } as PlotParams)
+            }
             useResizeHandler
             style={{ width: '100%', height: '100%', minHeight: '500px' }}
             onSelected={onSelected}

--- a/src/components/Trees/Trees.tsx
+++ b/src/components/Trees/Trees.tsx
@@ -4,6 +4,7 @@ import { Dropdown } from './Dropdown'
 import { Selector } from './Selector'
 import { defaultFamily, defaultOrder, getLevelValues } from './config'
 import { LinkButton, downloadIcon, externalLinkIcon, ExternalLink, helpIcon } from 'common'
+import { LoadIcon } from 'common/LoadIcon'
 
 export const Trees = () => {
     const [loading, setLoading] = React.useState(true)
@@ -137,7 +138,9 @@ export const Trees = () => {
                     </ExternalLink>
                 </div>
                 <div className='flex flex-col justify-center my-2'>
-                    <span className={loading ? 'text-center' : 'hidden'}>Loading...</span>
+                    <span className={loading ? 'text-center' : 'hidden'}>
+                        <LoadIcon />{' '}
+                    </span>
                     <div
                         className={
                             loading


### PR DESCRIPTION
### Summary of changes
- Add new lib react-tabs
- Add higher-order component for rendering tabs on Sequence and Family pages in explorer and fetching all RunIDs
- Handle conditional behaviour for large number of run_ids in query params
- Add info about available geo data vs total runs   
- Misc request: change text from `Analyse` -> `Palmprint` 

<!-- Update the PR title and describe your changes here. -->

### Related issues

<!-- Link any related issues here.
See <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>
-->
- https://github.com/serratus-bio/serratus.io/issues/111
- https://github.com/serratus-bio/serratus.io/issues/226
- https://github.com/serratus-bio/serratus.io/issues/115

### Checklist

- [x] Add tests or provide evidence of manual testing (if applicable)
- [x] PR checks pass (see [CONTRIBUTING.md](https://github.com/serratus-bio/serratus.io/blob/HEAD/CONTRIBUTING.md) for how to fix failing checks)
